### PR TITLE
[Tools] Fix z2 flash script failing

### DIFF
--- a/tools/AmebaZ2/Image_Tool_Linux/flash.sh
+++ b/tools/AmebaZ2/Image_Tool_Linux/flash.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Usage
-# ./flash.sh <Device Port> <Path to Output Dir>
-# ./flash.sh /dev/ttyUSB0 /path/to/output
+# ./flash.sh <Device Port> <Path to image>
+# ./flash.sh /dev/ttyUSB0 /path/to/image
 
 if [ -z "$1" ]
   then
@@ -12,17 +12,17 @@ fi
 
 if [ -z "$2" ]
   then
-    echo "No output directory provided"
+    echo "No image provided"
     exit
 fi
 
 SDK_ROOT_DIR=$PWD/../../..
-OUTPUT_DIR=$2
+IMAGE=$2
 
 rm -rf log*
 sudo ./Ameba_ImageTool -add device $1
 sudo ./Ameba_ImageTool -set baudrate 1500000
-sudo ./Ameba_ImageTool -set image $OUTPUT_DIR/flash_is.bin
+sudo ./Ameba_ImageTool -set image $IMAGE
 sudo ./Ameba_ImageTool -show
 read -p "Check if the settings are correct, then enter UART DOWNLOAD mode
 1) Push the UART DOWNLOAD button and keep it pressed.


### PR DESCRIPTION
- Change Ameba_ImageTool and flash.sh file permissions to executable
- Update flash.sh to pass in path to image instead of the path to image directory
- Example usage ./flash.sh "device port" "path to image"