### PR TITLE
[Tools] Flash script should explicitly set 0x08000000

### DIFF
--- a/tools/AmebaZ2/Image_Tool_Linux/flash.sh
+++ b/tools/AmebaZ2/Image_Tool_Linux/flash.sh
@@ -29,6 +29,7 @@ then
 else
   # if no address is given, use default address 0x08000000
   echo "Flashing to address 0x08000000"
+  sudo ./Ameba_ImageTool -set address 0x08000000 
 fi
 sudo ./Ameba_ImageTool -set image $IMAGE
 sudo ./Ameba_ImageTool -show


### PR DESCRIPTION
When using flashing script to flash image to other address other than the default 0x0800000, image tool will save this new address as the default address.
Need to set it back to 0x08000000 when no address is passed in. 