### PR TITLE
[DCT] Fix multi-fabric allocation issue

### DIFF
--- a/component/common/application/matter/application/matter_dcts.c
+++ b/component/common/application/matter/application/matter_dcts.c
@@ -108,6 +108,9 @@ const char* domainAllocator(const char *domain)
             case 5:
                 return matter_domain[7];
                 break;
+            default:
+                return "chip-fabric";
+                break;
         }
     }
     // chip-groupmsgcounters
@@ -428,18 +431,64 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
     }
     else
     {
-        ret = dct_open_module2(&handle, allocatedDomain);
-        if (DCT_SUCCESS != ret)
-        {
-            printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
-            goto exit;
+        if (strncmp(allocatedDomain, "chip-fabric", 11) == 0) {
+            int tmp = 0;
+            for(int i=3; i<=7; i++) {
+                if (strncmp(allocatedDomain, matter_domain[i], 13) != 0) {
+                    tmp = 1;
+                } else {
+                    tmp = 0;
+                    break;
+                }
+            }
+            if (tmp == 1) {
+                for(int j=3; j<=7; j++) {
+                    allocatedDomain = matter_domain[j];
+
+                    ret = dct_open_module2(&handle, allocatedDomain);
+                    if (DCT_SUCCESS != ret)
+                    {
+                        printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                        goto exit;
+                    }
+
+                    ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
+                    if (DCT_SUCCESS != ret)
+                        printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+                    dct_close_module2(&handle);
+                    
+                    if (DCT_SUCCESS == ret)
+                        goto exit;
+                }
+            } else {
+                ret = dct_open_module2(&handle, allocatedDomain);
+                if (DCT_SUCCESS != ret)
+                {
+                    printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                    goto exit;
+                }
+
+                ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
+                if (DCT_SUCCESS != ret)
+                    printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+                dct_close_module2(&handle);
+            }
+        } else {
+            ret = dct_open_module2(&handle, allocatedDomain);
+            if (DCT_SUCCESS != ret)
+            {
+                printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                goto exit;
+            }
+
+            ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
+            if (DCT_SUCCESS != ret)
+                printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+            dct_close_module2(&handle);
         }
-
-        ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
-        if (DCT_SUCCESS != ret)
-            printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
-
-        dct_close_module2(&handle);
     }
 
 exit:
@@ -761,20 +810,70 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
     }
     else
     {
-        ret = dct_open_module2(&handle, allocatedDomain);
-        if (DCT_SUCCESS != ret)
-        {
-            printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
-            goto exit;
+        if (strncmp(allocatedDomain, "chip-fabric", 11) == 0) {
+            int tmp = 0;
+            for(int i=3; i<=7; i++) {
+                if (strncmp(allocatedDomain, matter_domain[i], 13) != 0) {
+                    tmp = 1;
+                } else {
+                    tmp = 0;
+                    break;
+                }
+            }
+            if (tmp == 1) {
+                for(int j=3; j<=7; j++) {
+                    allocatedDomain = matter_domain[j];
+
+                    ret = dct_open_module2(&handle, allocatedDomain);
+                    if (DCT_SUCCESS != ret)
+                    {
+                        printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                        goto exit;
+                    }
+
+                    ret = dct_get_variable_new2(&handle, key, (char *)buf, &_bufSize);
+                    if (DCT_SUCCESS != ret)
+                        printf("%s : dct_get_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+                    *outLen = _bufSize;
+
+                    dct_close_module2(&handle);
+                    
+                    if (DCT_SUCCESS == ret)
+                        goto exit;
+                }
+            } else {
+                ret = dct_open_module2(&handle, allocatedDomain);
+                if (DCT_SUCCESS != ret)
+                {
+                    printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                    goto exit;
+                }
+
+                ret = dct_get_variable_new2(&handle, key, (char *)buf, &_bufSize);
+                if (DCT_SUCCESS != ret)
+                    printf("%s : dct_get_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+                *outLen = _bufSize;
+
+                dct_close_module2(&handle);
+            }
+        } else {
+            ret = dct_open_module2(&handle, allocatedDomain);
+            if (DCT_SUCCESS != ret)
+            {
+                printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, allocatedDomain, ret);
+                goto exit;
+            }
+
+            ret = dct_get_variable_new2(&handle, key, (char *)buf, &_bufSize);
+            if (DCT_SUCCESS != ret)
+                printf("%s : dct_get_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
+
+            *outLen = _bufSize;
+
+            dct_close_module2(&handle);
         }
-
-        ret = dct_get_variable_new2(&handle, key, (char *)buf, &_bufSize);
-        if (DCT_SUCCESS != ret)
-            printf("%s : dct_get_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
-
-        *outLen = _bufSize;
-
-        dct_close_module2(&handle);
     }
 
 exit:


### PR DESCRIPTION
* Unable to allocate multifabric to correct region when exceeding maximum multi-fabric -. When adding fabric, the fabric-index will increase despite removing an existing fabric. 
-. After adding 5 fabrics and removing one fabric, the next fabric added will have an fabric-index of 6, despite adding the fabric successfully, it is unable to read any data of fabric-index 6.
-. Temporary fix: loop within the 5 dct slots for multi-fabric to find available dct space to store if maximum multifabric isn't reached.