### PR TITLE
[factorydata] [flash] Write protection example

### DIFF
--- a/component/common/application/matter/application/README.md
+++ b/component/common/application/matter/application/README.md
@@ -1,0 +1,27 @@
+# Matter application
+
+## Files
+| File Name | Description |
+| ----------- | ----------- |
+| chip_porting.h | Header files with all the Matter API declarations |
+| matter_dcts | DCT API for Matter |
+| matter_timers | Timer API for Matter |
+| matter_utils | Utility API for Matter |
+| matter_wifis | WiFi API for Matter |
+| example_matter | Main Matter application example |
+| example_matter_write_protect | Matter write protection example |
+
+## Run Matter Example
+- To run Matter example, enable `CONFIG_MATTER_EXAMPLE` in `platform_opts.h`
+
+## Run Matter Write Protect Example
+- To run Matter write protect example, disable `CONFIG_MATTER_EXAMPLE` and enable `CONFIG_MATTER_WRITE_PROTECT_EXAMPLE` in `platform_opts.h`
+- This example adds/removes write protection to the last 4KB region of the external flash
+- External flash used: Winbond W25Q32JV (4MB)
+- Region protected: 0x3FF000 - 0x3FFFFF
+- Please check your external flash's datasheet for instructions on how to set the status registers correctly
+- To add write protection, enable `LOCK_FACTORY_DATA` in the source file
+- To remove write protection, disable `LOCK_FACTORY_DATA` in the source file
+- Make sure that `Status Register After Setting` is printed out with the correct value
+- In this example, status register after setting should be `0x44` if you are adding write protection and `0x00` if you are removing write protection
+- You may use image tool to erase/modify the contents of this flash region after adding write protection, it should fail

--- a/component/common/application/matter/application/example_matter_write_protect.c
+++ b/component/common/application/matter/application/example_matter_write_protect.c
@@ -1,0 +1,42 @@
+#include "FreeRTOS.h"
+#include "task.h"
+#include "platform/platform_stdlib.h"
+#include "example_matter_write_protect.h"
+#include "flash_api.h"
+
+//  This exmaple shows you how to add/remove write protection to the last 4KB region of the external flash
+//  Flash used: Winbond W25Q32JV (4MB)
+//  Region protected: 0x3FF000 - 0x3FFFFF
+//  Note: Please check your flash data sheet for instructions on how to set the status registers
+//  Note: Run this example only after you have flashed the matter factory data binary
+//  Note: To add write protection, enable LOCK_FACTORY_DATA
+//  Note: To remove write protection, disable LOCK_FACTORY_DATA
+
+#define LOCK_FACTORY_DATA 1
+
+static void example_matter_write_protect_task_thread(void *pvParameters)
+{
+    printf("\r\nMatter Flash Write Protection\r\n");
+    flash_t flash;
+    uint32_t address = 0x3FF000;
+    uint32_t length = 4096;
+    
+#if LOCK_FACTORY_DATA
+    printf("Status Register Before Setting = %x \r\n", flash_get_status(&flash));
+    flash_set_status(&flash, 0x44); // Lock factory data
+    printf("Status Register After Setting = %x \r\n", flash_get_status(&flash));
+#else
+    printf("Status Register Before Setting = %x \r\n", flash_get_status(&flash));
+    flash_set_status(&flash, flash_get_status(&flash) & (~0x44));    // Unlock factory data
+    printf("Status Register After Setting = %x \r\n", flash_get_status(&flash));
+#endif //LOCK_FACTORY_DATA
+
+    vTaskDelete(NULL);
+    return;
+}
+
+void example_matter_write_protect_task(void)
+{
+    if(xTaskCreate(example_matter_write_protect_task_thread, ((const char*)"example_matter_write_protect_task_thread"), 8092, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+        printf("\n\r%s xTaskCreate(example_matter_write_protect_task_thread) failed", __FUNCTION__);
+}

--- a/component/common/application/matter/application/example_matter_write_protect.h
+++ b/component/common/application/matter/application/example_matter_write_protect.h
@@ -1,0 +1,6 @@
+#ifndef EXAMPLE_MATTER_WRITE_PROTECT_H
+#define EXAMPLE_MATTER_WRITE_PROTECT_H
+
+void example_matter_write_protect_task(void);
+
+#endif /* EXAMPLE_MATTER_WRITE_PROTECT_H */

--- a/component/common/example/example_entry.c
+++ b/component/common/example/example_entry.c
@@ -362,6 +362,10 @@
 #include <example_matter.h>
 #endif
 
+#if defined(CONFIG_EXAMPLE_MATTER_WRITE_PROTECT) && (CONFIG_EXAMPLE_MATTER_WRITE_PROTECT == 1)
+#include <example_matter_write_protect.h>
+#endif
+
 /*
 	Preprocessor of example
 */
@@ -839,6 +843,10 @@ example_hilink();
 
 #if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
 	example_matter_task();
+#endif
+
+#if defined(CONFIG_EXAMPLE_MATTER_WRITE_PROTECT) && (CONFIG_EXAMPLE_MATTER_WRITE_PROTECT == 1)
+	example_matter_write_protect_task();
 #endif
 
 #if defined(API_TEST_MODE)

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
@@ -374,6 +374,7 @@ SRC_C += ../../../component/common/application/matter/application/matter_timers.
 SRC_C += ../../../component/common/application/matter/application/matter_utils.c
 SRC_C += ../../../component/common/application/matter/application/matter_wifis.c
 SRC_C += ../../../component/common/application/matter/application/example_matter.c
+SRC_C += ../../../component/common/application/matter/application/example_matter_write_protect.c
 SRC_C += ../../../component/common/application/matter/common/atcmd_matter.c
 SRC_C += ../../../component/common/application/matter/mbedtls/net_sockets.c
 

--- a/project/realtek_amebaz2_v0_example/inc/platform_opts.h
+++ b/project/realtek_amebaz2_v0_example/inc/platform_opts.h
@@ -90,6 +90,7 @@
 
 /* For Matter */
 #define CONFIG_EXAMPLE_MATTER   1
+#define CONFIG_EXAMPLE_MATTER_WRITE_PROTECT   0
 
 /* For WPS and P2P */
 #define CONFIG_ENABLE_WPS		0


### PR DESCRIPTION
- enable CONFIG_EXAMPLE_MATTER_WRITE_PROTECT at platform_opts.h
- to add write protection, enable LOCK_FACTORY_DATA
- to remove write protection, disable LOCK_FACTORY_DATA
- the example uses Winbond W25Q32JV (4MB) flash, check your flash datasheet
- run this example once you have flashed the factory data binary
- part 1 of #28 