### PR TITLE
[build] fix intermittent compile error when making matter lib

### DIFF
--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -166,7 +166,7 @@ CFLAGS =
 CFLAGS += -march=armv8-m.main+dsp -mthumb -mcmse -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os
 CFLAGS += -D__ARM_ARCH_8M_MAIN__=1 -gdwarf-3 -fstack-usage -fdata-sections -ffunction-sections 
 CFLAGS += -fdiagnostics-color=always -Wall -Wpointer-arith -Wno-write-strings 
-CFLAGS += -Wno-maybe-uninitialized --save-temps -c -MMD
+CFLAGS += -Wno-maybe-uninitialized -c -MMD
 CFLAGS += -DCONFIG_PLATFORM_8710C -DCONFIG_BUILD_RAM=1
 CFLAGS += -DV8M_STKOVF
 #for time64 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
@@ -166,7 +166,7 @@ CFLAGS =
 CFLAGS += -march=armv8-m.main+dsp -mthumb -mcmse -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os
 CFLAGS += -D__ARM_ARCH_8M_MAIN__=1 -gdwarf-3 -fstack-usage -fdata-sections -ffunction-sections 
 CFLAGS += -fdiagnostics-color=always -Wall -Wpointer-arith -Wno-write-strings 
-CFLAGS += -Wno-maybe-uninitialized --save-temps -c -MMD
+CFLAGS += -Wno-maybe-uninitialized -c -MMD
 CFLAGS += -DCONFIG_PLATFORM_8710C -DCONFIG_BUILD_RAM=1
 CFLAGS += -DV8M_STKOVF
 #for time64 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
@@ -166,7 +166,7 @@ CFLAGS =
 CFLAGS += -march=armv8-m.main+dsp -mthumb -mcmse -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os
 CFLAGS += -D__ARM_ARCH_8M_MAIN__=1 -gdwarf-3 -fstack-usage -fdata-sections -ffunction-sections 
 CFLAGS += -fdiagnostics-color=always -Wall -Wpointer-arith -Wno-write-strings 
-CFLAGS += -Wno-maybe-uninitialized --save-temps -c -MMD
+CFLAGS += -Wno-maybe-uninitialized -c -MMD
 CFLAGS += -DCONFIG_PLATFORM_8710C -DCONFIG_BUILD_RAM=1
 CFLAGS += -DV8M_STKOVF
 #for time64 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
@@ -169,7 +169,7 @@ CFLAGS =
 CFLAGS += -march=armv8-m.main+dsp -mthumb -mcmse -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os
 CFLAGS += -D__ARM_ARCH_8M_MAIN__=1 -gdwarf-3 -fstack-usage -fdata-sections -ffunction-sections 
 CFLAGS += -fdiagnostics-color=always -Wall -Wpointer-arith -Wno-write-strings 
-CFLAGS += -Wno-maybe-uninitialized --save-temps -c -MMD
+CFLAGS += -Wno-maybe-uninitialized -c -MMD
 CFLAGS += -DCONFIG_PLATFORM_8710C -DCONFIG_BUILD_RAM=1
 CFLAGS += -DV8M_STKOVF
 #for time64 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
@@ -166,7 +166,7 @@ CFLAGS =
 CFLAGS += -march=armv8-m.main+dsp -mthumb -mcmse -mfloat-abi=soft -D__thumb2__ -g -gdwarf-3 -Os
 CFLAGS += -D__ARM_ARCH_8M_MAIN__=1 -gdwarf-3 -fstack-usage -fdata-sections -ffunction-sections 
 CFLAGS += -fdiagnostics-color=always -Wall -Wpointer-arith -Wno-write-strings 
-CFLAGS += -Wno-maybe-uninitialized --save-temps -c -MMD
+CFLAGS += -Wno-maybe-uninitialized -c -MMD
 CFLAGS += -DCONFIG_PLATFORM_8710C -DCONFIG_BUILD_RAM=1
 CFLAGS += -DV8M_STKOVF
 #for time64 


### PR DESCRIPTION
- compile error is due to multiple files in matter sdk having the same name `IP.cpp`
- during compilation, all the `.ii` intermediate files will be put into `build/chip`, causing the two files to replace each other
- we don't need to save the `.ii` files when building libCHIP
- remove --save-temps flag to prevent saving `.ii` files