### PR TITLE
[build] use zapgen to generate zap files during compilation time

### DIFF
--- a/MATTER.md
+++ b/MATTER.md
@@ -37,6 +37,21 @@ Make sure ambz2_matter and connectedhomeip are on the same directory level
     source scripts/bootstrap.sh
 
     source scripts/activate.sh
+    
+## ZAP Installation
+- ZAP is automatically downloaded into `tools/matter/codegen_helpers/zap` during make
+- If you need to export the path to `ZAP_INSTALL_PATH` outside of make (for eg, launching ZAP GUI, building `chip-tool`, etc), you can add below lines to your `~/.bashrc` file for convenience
+
+```bash
+# Matter - export zap path
+export ZAP_INSTALL_PATH="<zap-path>"
+```
+- You may also choose to append the zap folder path to `PATH`
+
+```bash
+# Matter - export zap path
+export PATH="<zap-path>":$PATH
+```
 
 ## Make CHIP library by gn and Make lib_main.a
 ### all-clusters-app

--- a/component/common/application/matter/example/light/Makefile
+++ b/component/common/application/matter/example/light/Makefile
@@ -3,7 +3,7 @@ SDKROOTDIR := $(BASEDIR)/../../../../../..
 AMEBAZ2_TOOLDIR	= $(SDKROOTDIR)/component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(SDKROOTDIR)/third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-CODEGENDIR = $(SDKROOTDIR)/tools/matter/codegen_helpers/gen
+MATTER_TOOLDIR = $(SDKROOTDIR)/tools/matter
 
 OS := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
@@ -38,20 +38,25 @@ endif
 endif
 	@echo Toolchain unzip done!
 
-.PHONY: mkdir_codegen
-mkdir_codegen:
-	if [ ! -d $(SDKROOTDIR)/tools/matter/codegen_helpers/gen ]; then mkdir $(SDKROOTDIR)/tools/matter/codegen_helpers/gen; fi
+.PHONY: check_zap
+check_zap:
+	cd $(MATTER_TOOLDIR)/codegen_helpers/ && \
+	./check_zap.sh
 
 .PHONY: light
-light: toolchain mkdir_codegen
-	python3 $(SDKROOTDIR)/third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir $(SDKROOTDIR)/tools/matter/codegen_helpers/gen --expected-outputs $(SDKROOTDIR)/tools/matter/codegen_helpers/expected.outputs $(SDKROOTDIR)/third_party/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.matter
-	python3 $(SDKROOTDIR)/third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file $(SDKROOTDIR)/third_party/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.zap > $(SDKROOTDIR)/tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 $(SDKROOTDIR)/tools/matter/codegen_helpers/parse_clusters.py --cluster_file $(SDKROOTDIR)/tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path $(SDKROOTDIR)/third_party/connectedhomeip
-	@$(MAKE) -f lib_chip_light_core.mk all
-	@$(MAKE) -f lib_chip_light_main.mk all
+light: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/lighting-app/ameba/build/chip/codegen/zap-generated examples/lighting-app/lighting-common/lighting-app.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/lighting-app/ameba/build/chip/codegen/zap-generated examples/lighting-app/lighting-common/lighting-app.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/lighting-app/lighting-common/lighting-app.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/lighting-app/lighting-common/lighting-app.zap > $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip_light_core.mk all
+	$(MAKE) -f lib_chip_light_main.mk all
 
 .PHONY: clean
 clean:
-	@$(MAKE) -f lib_chip_light_core.mk clean
 	@$(MAKE) -f lib_chip_light_main.mk clean
+	@$(MAKE) -f lib_chip_light_core.mk clean
 	rm -rf $(SDKROOTDIR)/tools/matter/codegen_helpers/gen

--- a/component/common/application/matter/example/light/README.md
+++ b/component/common/application/matter/example/light/README.md
@@ -40,6 +40,21 @@ Ensure that `CONFIG_EXAMPLE_MATTER_CHIPTEST` is disabled.
   
     cd connectedhomeip
     source scripts/activate.sh
+
+### ZAP Installation
+- ZAP is automatically downloaded into `tools/matter/codegen_helpers/zap` during make
+- If you need to export the path to `ZAP_INSTALL_PATH` outside of make (for eg, launching ZAP GUI, building `chip-tool`, etc), you can add below lines to your `~/.bashrc` file for convenience
+
+```bash
+# Matter - export zap path
+export ZAP_INSTALL_PATH="<zap-path>"
+```
+- You may also choose to append the zap folder path to `PATH`
+
+```bash
+# Matter - export zap path
+export PATH="<zap-path>":$PATH
+```
   
 ### Build Matter Libraries
 

--- a/component/common/application/matter/example/light/lib_chip_light_core.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_core.mk
@@ -7,6 +7,7 @@ SDKROOTDIR := $(BASEDIR)/../../../../../..
 AMEBAZ2_TOOLDIR	= $(SDKROOTDIR)/component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(SDKROOTDIR)/third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
+MATTER_TOOLDIR = $(SDKROOTDIR)/tools/matter
 
 OS := $(shell uname)
 
@@ -230,25 +231,28 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(SDKROOTDIR)/component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+	
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -7,7 +7,7 @@ SDKROOTDIR := $(BASEDIR)/../../../../../..
 AMEBAZ2_TOOLDIR	= $(SDKROOTDIR)/component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(SDKROOTDIR)/third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-CODEGENDIR = $(SDKROOTDIR)/tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -212,11 +212,10 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-
-SRC_CPP += $(CHIPDIR)/zzz_generated/lighting-app/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/examples/providers/DeviceInfoProviderImpl.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/Makefile
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/Makefile
@@ -3,6 +3,9 @@ all: is
 OS := $(shell uname)
 LBITS := $(shell getconf LONG_BIT)
 
+CHIPDIR = ../../../third_party/connectedhomeip
+MATTER_TOOLDIR = ../../../tools/matter
+
 .PHONY: toolchain
 toolchain:
 	@echo Toolchain unzipping...
@@ -35,7 +38,12 @@ endif
 
 .PHONY: mkdir_codegen
 mkdir_codegen:
-	if [ ! -d ../../../tools/matter/codegen_helpers/gen ]; then mkdir ../../../tools/matter/codegen_helpers/gen; fi
+	if [ ! -d "$(MATTER_TOOLDIR)/codegen_helpers/gen" ]; then mkdir "$(MATTER_TOOLDIR)/codegen_helpers/gen"; fi
+
+.PHONY: check_zap
+check_zap:
+	cd $(MATTER_TOOLDIR)/codegen_helpers/ && \
+	./check_zap.sh
 
 .PHONY: is
 is: toolchain
@@ -51,44 +59,64 @@ clean:
 	@$(MAKE) -f application.is.mk clean
 
 .PHONY: all_clusters
-all_clusters: toolchain mkdir_codegen
-	python3 ../../../third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir ../../../tools/matter/codegen_helpers/gen --expected-outputs ../../../tools/matter/codegen_helpers/expected.outputs ../../../third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
-	python3 ../../../third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file ../../../third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap > ../../../tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 ../../../tools/matter/codegen_helpers/parse_clusters.py --cluster_file ../../../tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path ../../../third_party/connectedhomeip
-	@$(MAKE) -f lib_chip.mk all
-	@$(MAKE) -f lib_chip_main.mk all
+all_clusters: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/all-clusters-app/ameba/build/chip/codegen/zap-generated examples/all-clusters-app/all-clusters-common/all-clusters-app.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/all-clusters-app/ameba/build/chip/codegen/zap-generated examples/all-clusters-app/all-clusters-common/all-clusters-app.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap > $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip.mk all
+	$(MAKE) -f lib_chip_main.mk all
 
 .PHONY: light
-light: toolchain mkdir_codegen
-	python3 ../../../third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir ../../../tools/matter/codegen_helpers/gen --expected-outputs ../../../tools/matter/codegen_helpers/expected.outputs ../../../third_party/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.matter
-	python3 ../../../third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file ../../../third_party/connectedhomeip/examples/lighting-app/lighting-common/lighting-app.zap > ../../../tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 ../../../tools/matter/codegen_helpers/parse_clusters.py --cluster_file ../../../tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path ../../../third_party/connectedhomeip
-	@$(MAKE) -f lib_chip_light_core.mk all
-	@$(MAKE) -f lib_chip_light_main.mk all
+light: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/lighting-app/ameba/build/chip/codegen/zap-generated examples/lighting-app/lighting-common/lighting-app.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/lighting-app/ameba/build/chip/codegen/zap-generated examples/lighting-app/lighting-common/lighting-app.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/lighting-app/lighting-common/lighting-app.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/lighting-app/lighting-common/lighting-app.zap > $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/lighting-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip_light_core.mk all
+	$(MAKE) -f lib_chip_light_main.mk all
 
 .PHONY: switch
-switch: toolchain mkdir_codegen
-	python3 ../../../third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir ../../../tools/matter/codegen_helpers/gen --expected-outputs ../../../tools/matter/codegen_helpers/expected.outputs ../../../third_party/connectedhomeip/examples/light-switch-app/light-switch-common/light-switch-app.matter
-	python3 ../../../third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file ../../../third_party/connectedhomeip/examples/light-switch-app/light-switch-common/light-switch-app.zap > ../../../tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 ../../../tools/matter/codegen_helpers/parse_clusters.py --cluster_file ../../../tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path ../../../third_party/connectedhomeip
-	@$(MAKE) -f lib_chip_switch_core.mk all
-	@$(MAKE) -f lib_chip_switch_main.mk all
+switch: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/light-switch-app/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/light-switch-app/ameba/build/chip/codegen/zap-generated examples/light-switch-app/light-switch-common/light-switch-app.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/light-switch-app/ameba/build/chip/codegen/zap-generated examples/light-switch-app/light-switch-common/light-switch-app.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/light-switch-app/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/light-switch-app/light-switch-common/light-switch-app.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/light-switch-app/light-switch-common/light-switch-app.zap > $(CHIPDIR)/examples/light-switch-app/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/light-switch-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip_switch_core.mk all
+	$(MAKE) -f lib_chip_switch_main.mk all
 
 .PHONY: otar
-otar: toolchain mkdir_codegen
-	python3 ../../../third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir ../../../tools/matter/codegen_helpers/gen --expected-outputs ../../../tools/matter/codegen_helpers/expected.outputs ../../../third_party/connectedhomeip/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
-	python3 ../../../third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file ../../../third_party/connectedhomeip/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap > ../../../tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 ../../../tools/matter/codegen_helpers/parse_clusters.py --cluster_file ../../../tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path ../../../third_party/connectedhomeip
-	@$(MAKE) -f lib_chip_otar_core.mk all
-	@$(MAKE) -f lib_chip_otar_main.mk all
+otar: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/ota-requestor-app/ameba/build/chip/codegen/zap-generated examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/ota-requestor-app/ameba/build/chip/codegen/zap-generated examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.zap > $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip_otar_core.mk all
+	$(MAKE) -f lib_chip_otar_main.mk all
 
 .PHONY: chef
-chef: toolchain mkdir_codegen
-	python3 ../../../third_party/connectedhomeip/scripts/codegen.py --generator cpp-app --output-dir ../../../tools/matter/codegen_helpers/gen --expected-outputs ../../../tools/matter/codegen_helpers/expected.outputs ../../../third_party/connectedhomeip/examples/chef/devices/$(SAMPLE_NAME).matter
-	python3 ../../../third_party/connectedhomeip/src/app/zap_cluster_list.py --zap_file ../../../third_party/connectedhomeip/examples/chef/devices/$(SAMPLE_NAME).zap > ../../../tools/matter/codegen_helpers/gen/cluster-file.txt
-	python3 ../../../tools/matter/codegen_helpers/parse_clusters.py --cluster_file ../../../tools/matter/codegen_helpers/gen/cluster-file.txt --chip_path ../../../third_party/connectedhomeip
-	@$(MAKE) -f lib_chip_chef_core.mk all
-	@$(MAKE) -f lib_chip_chef_main.mk all
+chef: toolchain check_zap
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	mkdir -p $(CHIPDIR)/examples/chef/ameba/build/chip/codegen/zap-generated && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/matter-idl.json --output-dir examples/chef/ameba/build/chip/codegen/zap-generated examples/chef/devices/$(SAMPLE_NAME).zap && \
+	python3 $(CHIPDIR)/scripts/tools/zap/generate.py --no-prettify-output --templates src/app/zap-templates/app-templates.json --output-dir examples/chef/ameba/build/chip/codegen/zap-generated examples/chef/devices/$(SAMPLE_NAME).zap && \
+	python3 $(CHIPDIR)/scripts/codegen.py --generator cpp-app --output-dir $(CHIPDIR)/examples/chef/ameba/build/chip/codegen --expected-outputs $(MATTER_TOOLDIR)/codegen_helpers/expected.outputs $(CHIPDIR)/examples/chef/devices/$(SAMPLE_NAME).matter && \
+	python3 $(CHIPDIR)/src/app/zap_cluster_list.py --zap_file $(CHIPDIR)/examples/chef/devices/$(SAMPLE_NAME).zap > $(CHIPDIR)/examples/chef/ameba/build/chip/codegen/cluster-file.txt && \
+	python3 $(MATTER_TOOLDIR)/codegen_helpers/parse_clusters.py --cluster_file $(CHIPDIR)/examples/chef/ameba/build/chip/codegen/cluster-file.txt --chip_path $(CHIPDIR) && \
+	$(MAKE) -f lib_chip_chef_core.mk all
+	$(MAKE) -f lib_chip_chef_main.mk all
 
 .PHONY: is_matter
 is_matter: toolchain
@@ -97,18 +125,17 @@ is_matter: toolchain
 	
 .PHONY: clean_matter
 clean_matter:
-	@$(MAKE) -f lib_chip.mk clean
 	@$(MAKE) -f lib_chip_main.mk clean
-	@$(MAKE) -f lib_chip_light_core.mk clean
+	@$(MAKE) -f lib_chip.mk clean
 	@$(MAKE) -f lib_chip_light_main.mk clean
-	@$(MAKE) -f lib_chip_switch_core.mk clean
+	@$(MAKE) -f lib_chip_light_core.mk clean
 	@$(MAKE) -f lib_chip_switch_main.mk clean
-	@$(MAKE) -f lib_chip_otar_core.mk clean
+	@$(MAKE) -f lib_chip_switch_core.mk clean
 	@$(MAKE) -f lib_chip_otar_main.mk clean
-	@$(MAKE) -f lib_chip_chef_core.mk clean
+	@$(MAKE) -f lib_chip_otar_core.mk clean
 	@$(MAKE) -f lib_chip_chef_main.mk clean
+	@$(MAKE) -f lib_chip_chef_core.mk clean
 	@$(MAKE) -f application.is.matter.mk clean
-	rm -rf ../../../tools/matter/codegen_helpers/gen
 
 debug: toolchain
 	@$(MAKE) -f application.is.mk debug

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -7,6 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip
+MATTER_TOOLDIR = $(BASEDIR)/../../../tools/matter
 
 OS := $(shell uname)
 
@@ -237,27 +238,29 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	echo $(BASEDIR)
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	if [ ! d "$(OUTPUT_DIR")" ]; then mkdir -p "$(OUTPUT_DIR)"; fi && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(BASEDIR)/../../../component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
@@ -7,6 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
+MATTER_TOOLDIR = $(BASEDIR)/../../../tools/matter
 
 OS := $(shell uname)
 
@@ -230,25 +231,27 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	echo $(BASEDIR)
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(BASEDIR)/../../../component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -7,7 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-CODEGENDIR = $(BASEDIR)/../../../tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -207,11 +207,10 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-
-SRC_CPP += $(CHIPDIR)/examples/chef/out/lighting-app/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/examples/chef/ameba/main/chipinterface.cpp
 SRC_CPP += $(CHIPDIR)/examples/chef/ameba/main/DeviceCallbacks.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
@@ -7,6 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
+MATTER_TOOLDIR = $(BASEDIR)/../../../tools/matter
 
 OS := $(shell uname)
 
@@ -230,26 +231,28 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	echo $(BASEDIR)
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/lighting-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/lighting-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(BASEDIR)/../../../component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+	
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -7,7 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/lighting-app/ameba/build/chip
-CODEGENDIR = $(BASEDIR)/../../../tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -207,11 +207,10 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-
-SRC_CPP += $(CHIPDIR)/zzz_generated/lighting-app/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/examples/lighting-app/ameba/main/chipinterface.cpp
 SRC_CPP += $(CHIPDIR)/examples/lighting-app/ameba/main/DeviceCallbacks.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -6,7 +6,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip
-CODEGENDIR = $(BASEDIR)/../../../tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -213,8 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
-
-SRC_CPP += $(CHIPDIR)/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
@@ -7,6 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip
+MATTER_TOOLDIR = $(BASEDIR)/../../../tools/matter
 
 OS := $(shell uname)
 
@@ -233,26 +234,28 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	echo $(BASEDIR)
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(BASEDIR)/../../../component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -7,7 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/ota-requestor-app/ameba/build/chip
-CODEGENDIR = $(BASEDIR)/../../../tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -209,11 +209,10 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-
-SRC_CPP += $(CHIPDIR)/zzz_generated/ota-requestor-app/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/examples/ota-requestor-app/ameba/main/chipinterface.cpp
 SRC_CPP += $(CHIPDIR)/examples/ota-requestor-app/ameba/main/Globals.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
@@ -7,6 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/light-switch-app/ameba/build/chip
+MATTER_TOOLDIR = $(BASEDIR)/../../../tools/matter
 
 OS := $(shell uname)
 
@@ -230,27 +231,29 @@ CHIP_CXXFLAGS += $(INCLUDES)
 all: GENERATE_NINJA
 
 GENERATE_NINJA:
-	echo "INSTALL CHIP..."
-	echo $(BASEDIR)
-	mkdir -p $(OUTPUT_DIR)
-	echo                                   > $(OUTPUT_DIR)/args.gn
-	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn
-	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn
-	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn
-	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn
-	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn
-	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni
-	mkdir -p $(CHIPDIR)/config/ameba/components/chip
-	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/light-switch-app/ameba/build/chip
-	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/light-switch-app/ameba/build/chip :ameba
+	export ZAP_INSTALL_PATH="$(MATTER_TOOLDIR)/codegen_helpers/zap" && \
+	echo "INSTALL CHIP..." && \
+	echo $(BASEDIR) && \
+	mkdir -p $(OUTPUT_DIR) && \
+	echo                                   > $(OUTPUT_DIR)/args.gn && \
+	echo "import(\"//args.gni\")"          >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_c  = [$(foreach word,$(CHIP_CFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'  >> $(OUTPUT_DIR)/args.gn && \
+	echo target_cflags_cc = [$(foreach word,$(CHIP_CXXFLAGS),\"$(word)\",)] | sed -e 's/=\"/=\\"/g;s/\"\"/\\"\"/g;'   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_ar = \"arm-none-eabi-ar\"    >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cc = \"arm-none-eabi-gcc\"   >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cxx = \"arm-none-eabi-c++\"  >> $(OUTPUT_DIR)/args.gn && \
+	echo ameba_cpu = \"ameba\"               >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_enable_ota_requestor = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
+	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/light-switch-app/ameba/build/chip && \
+	cd $(CHIPDIR)/config/ameba/components/chip ; ninja -C $(CHIPDIR)/examples/light-switch-app/ameba/build/chip :ameba && \
 	cp -f $(OUTPUT_DIR)/lib/* $(BASEDIR)/../../../component/soc/realtek/8710c/misc/bsp/lib/common/GCC
+
 #*****************************************************************************#
 #              CLEAN GENERATED FILES                                          #
 #*****************************************************************************#

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -7,7 +7,7 @@ BASEDIR := $(shell pwd)
 AMEBAZ2_TOOLDIR	= $(BASEDIR)/../../../component/soc/realtek/8710c/misc/iar_utility
 CHIPDIR = $(BASEDIR)/../../../third_party/connectedhomeip
 OUTPUT_DIR = $(CHIPDIR)/examples/light-switch-app/ameba/build/chip
-CODEGENDIR = $(BASEDIR)/../../../tools/matter/codegen_helpers/gen
+CODEGENDIR = $(OUTPUT_DIR)/codegen
 
 OS := $(shell uname)
 
@@ -210,8 +210,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
-
-SRC_CPP += $(CHIPDIR)/zzz_generated/light-switch-app/zap-generated/IMClusterCommandHandler.cpp
+SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp

--- a/tools/matter/codegen_helpers/check_zap.sh
+++ b/tools/matter/codegen_helpers/check_zap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DIR=$(dirname "$0")
+ZIPFILE=$DIR/zap-linux.zip
+ZAPDIR=$DIR/zap
+
+echo "Downloading ZAP"
+
+if [ ! -f "$ZIPFILE" ]; then
+    curl -L https://github.com/project-chip/zap/releases/download/v2023.01.09-nightly/zap-linux.zip -o "$ZIPFILE"
+else
+    echo "$ZIPFILE already exists"
+fi
+
+echo "Unzipping..."
+if [ ! -d "$ZAPDIR" ]; then
+    unzip "$ZIPFILE" -d "$ZAPDIR"
+else
+    echo "$ZAPDIR already exists"
+fi


### PR DESCRIPTION
- add `check_zap.sh` to install zap under `tools/matter/codegen_helpers/zap`
- make commands will call `check_zap.sh` and then export the zap path to `ZAP_INSTALL_PATH`
- shifted codegen output to matter sdk under application examples
- switch order of make clean (clean main first, then clean core) in order to preserve `cluster-file.txt` to avoid error