### PR TITLE
[bluetooth] fix potential nullptr dereference

### DIFF
--- a/component/common/bluetooth/realtek/sdk/board/common/src/cycle_queue.c
+++ b/component/common/bluetooth/realtek/sdk/board/common/src/cycle_queue.c
@@ -158,6 +158,7 @@ bool MallocCycQueue()
     cyc_buffer = osif_mem_alloc(RAM_TYPE_DATA_ON, MAX_BUFFER_SIZE);
     if (cyc_buffer == NULL) {
         printf("cyc_buffer is NULL, malloc fail\r\n");
+        return false;
     }
     memset(cyc_buffer, 0, MAX_BUFFER_SIZE);
     pRead = 0;


### PR DESCRIPTION
- MallocCycQueue(), return false when memory alloc fail for cyc_buffer
fix #66 