### PR TITLE
[mbedtls] hw crypto support on mbedtls 2.28

### DIFF
--- a/component/common/application/matter/common/mbedtls/mbedtls_config.h
+++ b/component/common/application/matter/common/mbedtls/mbedtls_config.h
@@ -34,6 +34,9 @@
 #define _CRT_SECURE_NO_DEPRECATE 1
 #endif
 
+#define RTL_HW_CRYPTO
+//#define SUPPORT_HW_SW_CRYPTO
+
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 
 /**

--- a/component/common/network/ssl/mbedtls-matter/include/mbedtls/aes.h
+++ b/component/common/network/ssl/mbedtls-matter/include/mbedtls/aes.h
@@ -53,6 +53,7 @@
 /* padlock.c and aesni.c rely on these values! */
 #define MBEDTLS_AES_ENCRYPT     1 /**< AES encryption. */
 #define MBEDTLS_AES_DECRYPT     0 /**< AES decryption. */
+#define RTL_CRYPTO_FRAGMENT 15360
 
 /* Error codes in range 0x0020-0x0022 */
 /** Invalid key length. */
@@ -100,6 +101,10 @@ typedef struct mbedtls_aes_context
                                      <li>Simplifying key expansion in the 256-bit
                                          case by generating an extra round key.
                                          </li></ul> */
+#ifdef RTL_HW_CRYPTO
+    unsigned char enc_key[32];
+    unsigned char dec_key[32];
+#endif
 }
 mbedtls_aes_context;
 

--- a/component/common/network/ssl/mbedtls-matter/library/platform.c
+++ b/component/common/network/ssl/mbedtls-matter/library/platform.c
@@ -71,6 +71,12 @@ int mbedtls_platform_set_calloc_free( void * (*calloc_func)( size_t, size_t ),
 {
     mbedtls_calloc_func = calloc_func;
     mbedtls_free_func = free_func;
+
+    /* Realtek added to initialize HW crypto function pointers
+    * mbedtls RAM codes use function pointers in platform memory implementation
+    * Not use malloc/free in ssl ram map for mbedtls RAM codes
+    */
+    platform_set_malloc_free( (void*(*)( size_t ))calloc_func, free_func);
     return( 0 );
 }
 #endif /* MBEDTLS_PLATFORM_MEMORY &&

--- a/component/common/network/ssl/ssl_func_stubs/rom/rom_ssl_func_stubs.h
+++ b/component/common/network/ssl/ssl_func_stubs/rom/rom_ssl_func_stubs.h
@@ -22,6 +22,13 @@
 #include "mbedtls/pk_internal.h"
 #include "mbedtls/arc4.h"
 
+#ifndef u32
+typedef uint32_t u32;
+#endif
+#ifndef u8
+typedef uint8_t  u8;
+#endif
+
 #if defined(CONFIG_PLATFORM_8710C) && defined(CONFIG_BUILD_SECURE) && (CONFIG_BUILD_SECURE == 1)
 typedef struct ssl_func_stubs_s {
 	// ssl_ram_map

--- a/component/common/network/ssl/ssl_func_stubs/ssl_func_stubs.c
+++ b/component/common/network/ssl/ssl_func_stubs/ssl_func_stubs.c
@@ -13,7 +13,7 @@ ssl_func_stubs_t __ram_stubs_ssl;
 
 extern const ssl_func_stubs_t __rom_stubs_ssl;
 
-#if defined(CONFIG_PLATFORM_8710C) && (MBEDTLS_VERSION_NUMBER==0x02100300)
+#if defined(CONFIG_PLATFORM_8710C) && ((MBEDTLS_VERSION_NUMBER==0x02100300) || (MBEDTLS_VERSION_NUMBER==0x021C0000) || (MBEDTLS_VERSION_NUMBER==0x021C0100))
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
 int platform_set_malloc_free(
 	void *(*ssl_calloc)(unsigned int, unsigned int),
@@ -328,13 +328,6 @@ int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
 {
 	return __ram_stubs_ssl.mbedtls_mpi_is_prime(X, f_rng, p_rng);
 }
-#else
-int mbedtls_mpi_is_prime_ext( const mbedtls_mpi *X, int rounds,
-                              int (*f_rng)(void *, unsigned char *, size_t),
-                              void *p_rng )
-{
-	return __rom_stubs_ssl.mbedtls_mpi_is_prime(X, f_rng, p_rng);
-}
 #endif
 #endif
 
@@ -396,7 +389,7 @@ int platform_set_malloc_free(
 	/* Variables */
 	rom_ssl_ram_map.use_hw_crypto_func = 1;
 	
-#if defined(CONFIG_PLATFORM_8710C) && (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER==0x02100300)
+#if defined(CONFIG_PLATFORM_8710C) && ((defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER==0x02100300 || MBEDTLS_VERSION_NUMBER==0x021C0000 || MBEDTLS_VERSION_NUMBER==0x021C0100)))
 	//AES HW CRYPTO
 	rtl_cryptoEngine_init();
 	rom_ssl_ram_map.hw_crypto_aes_ecb_init = rtl_crypto_aes_ecb_init;
@@ -406,7 +399,7 @@ int platform_set_malloc_free(
 	rom_ssl_ram_map.hw_crypto_aes_cbc_decrypt = rtl_crypto_aes_cbc_decrypt;
 	rom_ssl_ram_map.hw_crypto_aes_cbc_encrypt = rtl_crypto_aes_cbc_encrypt;
 #endif
-#if (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER == 0x02040000) || ((defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER==0x02100300) && (defined(MBEDTLS_USE_ROM_API) || defined(MBEDTLS_BIGNUM_USE_S_ROM_API)))
+#if (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER == 0x02040000) || ((defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER==0x02100300 || MBEDTLS_VERSION_NUMBER==0x021C0000 || MBEDTLS_VERSION_NUMBER==0x021C0100)) && (defined(MBEDTLS_USE_ROM_API) || defined(MBEDTLS_BIGNUM_USE_S_ROM_API)))
 #if defined(MBEDTLS_BIGNUM_USE_S_ROM_API)
 	if((*((volatile u32*)(0x400001F0)) & (BIT4|BIT5|BIT6|BIT7))>>4 >= 0x3)
 	{
@@ -426,7 +419,7 @@ int platform_set_malloc_free(
 #if defined(CONFIG_PLATFORM_8710C)
 	/// DES funtions are on longer supported on AmebaZ2's HW crypto
 	/// Must set them to NULL, so it will use SW instead of HW even use_hw_crypto_func is enabled
-#if (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER==0x02100300)
+#if (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER == 0x02040000) || ((defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER==0x02100300 || MBEDTLS_VERSION_NUMBER==0x021C0000 || MBEDTLS_VERSION_NUMBER==0x021C0100)) && defined(MBEDTLS_USE_ROM_API))
 	//DES HW CRYPTO
 	rom_ssl_ram_map.hw_crypto_des_cbc_init = NULL;
 	rom_ssl_ram_map.hw_crypto_des_cbc_decrypt = NULL;
@@ -2039,7 +2032,7 @@ int mbedtls_pk_write_key_pem(mbedtls_pk_context *key, unsigned char *buf, size_t
 	return __rom_stubs_ssl.mbedtls_pk_write_key_pem(key, buf, size);
 }
 
-#if defined(MBEDTLS_USE_ROM_API) && (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER==0x02100300)
+#if defined(MBEDTLS_USE_ROM_API) && (defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER==0x02100300 || MBEDTLS_VERSION_NUMBER==0x021C0000 || MBEDTLS_VERSION_NUMBER==0x021C0100))
 int mbedtls_md5_starts_ret( mbedtls_md5_context *ctx )
 {
 	__rom_stubs_ssl.mbedtls_md5_starts(ctx);
@@ -2133,7 +2126,7 @@ int mbedtls_pk_verify_restartable( mbedtls_pk_context *ctx,
 	return __rom_stubs_ssl.mbedtls_pk_verify(ctx, md_alg, hash, hash_len, sig, sig_len);
 }
 #endif /* MBEDTLS_USE_ROM_API */
-#if defined(ENABLE_AMAZON_COMMON) || (defined(MBEDTLS_VERSION_NUMBER) && MBEDTLS_VERSION_NUMBER==0x02100300)
+#if defined(ENABLE_AMAZON_COMMON) || (defined(MBEDTLS_VERSION_NUMBER) && (MBEDTLS_VERSION_NUMBER==0x02100300 || MBEDTLS_VERSION_NUMBER==0x021C0000 || MBEDTLS_VERSION_NUMBER==0x021C0100))
 #if !defined(SUPPORT_HW_SSL_HMAC_SHA256)
 /* sha256 */
 int mbedtls_sha256_starts_ret(mbedtls_sha256_context *ctx, int is224)

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
@@ -558,7 +558,7 @@ SRC_C += ../../../component/common/network/ssl/mbedtls-matter/library/xtea.c
 
 #network - ssl - ssl_ram_map
 SRC_C += ../../../component/common/network/ssl/ssl_ram_map/rom/rom_ssl_ram_map.c
-#SRC_C += ../../../component/common/network/ssl/ssl_func_stubs/ssl_func_stubs.c
+SRC_C += ../../../component/common/network/ssl/ssl_func_stubs/ssl_func_stubs.c
 
 #network - websocket
 SRC_C += ../../../component/common/network/websocket/wsclient_tls.c


### PR DESCRIPTION
- HW crypto supported by z2: AES CBC and ECB mode
  - `mbedtls_aes_setkey_enc`, `mbedtls_aes_setkey_dec`, `mbedtls_aes_crypt_ebc`, `mbedtls_aes_crypt_cbc`
- remove DES, no longer supported on z2
- to enable HW crypto, enable `RTL_HW_CRYPTO` in `mbedtls_config.h` (enabled by default)