### PR TITLE
[build] remove af-event.cpp from build and add route hook to all examples

### DIFF
--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -193,7 +193,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -187,7 +187,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -178,6 +178,8 @@ INCLUDES += -I$(CODEGENDIR)
 # -------------------------------------------------------------------
 
 SRC_C =
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -187,7 +187,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -178,6 +178,8 @@ INCLUDES += -I$(CODEGENDIR)
 # -------------------------------------------------------------------
 
 SRC_C =
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -193,7 +193,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -180,6 +180,8 @@ INCLUDES += -I$(CODEGENDIR)
 # -------------------------------------------------------------------
 
 SRC_C =
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -189,7 +189,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -181,6 +181,8 @@ INCLUDES += -I$(CODEGENDIR)
 # -------------------------------------------------------------------
 
 SRC_C =
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_hook.c
+SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -190,7 +190,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Server.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
-SRC_CPP += $(CHIPDIR)/src/app/util/af-event.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp


### PR DESCRIPTION
- matter SHA `d7971c0` removes af-event.[h |cpp] files
- remove af-event.cpp from all app's lib_main files 
- add route hook to all examples