### PR TITLE
[portinglayer] update the cluster and attribute id filepath

### DIFF
--- a/component/common/application/matter/core/matter_core.cpp
+++ b/component/common/application/matter/core/matter_core.cpp
@@ -5,9 +5,9 @@
 #include "matter_ota.h"
 #include <DeviceInfoProviderImpl.h>
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/command-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Commands.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/af-types.h>
 #include <app/util/attribute-storage.h>

--- a/component/common/application/matter/core/matter_interaction.cpp
+++ b/component/common/application/matter/core/matter_interaction.cpp
@@ -2,10 +2,10 @@
 #include "matter_events.h"
 #include "matter_interaction.h"
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 
 using namespace ::chip;
 using namespace ::chip::app;
@@ -150,17 +150,17 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
 
     switch (path.mClusterId)
     {
-    case ZCL_ON_OFF_CLUSTER_ID:
+    case Clusters::OnOff::Id:
         uplink_event.mHandler = matter_driver_attribute_update;
         PostUplinkEvent(&uplink_event);
         break;
 
-    case ZCL_LEVEL_CONTROL_CLUSTER_ID:
+    case Clusters::LevelControl::Id:
         uplink_event.mHandler = matter_driver_attribute_update;
         PostUplinkEvent(&uplink_event);
         break;
 
-    case ZCL_IDENTIFY_CLUSTER_ID:
+    case Clusters::Identify::Id:
         uplink_event.mHandler = matter_driver_attribute_update;
         PostUplinkEvent(&uplink_event);
         break;

--- a/component/common/application/matter/example/light/matter_drivers.cpp
+++ b/component/common/application/matter/example/light/matter_drivers.cpp
@@ -3,10 +3,10 @@
 #include "led_driver.h"
 #include "gpio_irq_api.h"
 
-#include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
-#include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app-common/zap-generated/ids/Clusters.h>
 
 using namespace ::chip::app;
 
@@ -125,21 +125,21 @@ void matter_driver_attribute_update(AppEvent *aEvent)
 
     switch(path.mClusterId)
     {
-    case ZCL_ON_OFF_CLUSTER_ID:
-        if(path.mAttributeId == ZCL_ON_OFF_ATTRIBUTE_ID)
+    case Clusters::OnOff::Id:
+        if(path.mAttributeId == Clusters::OnOff::Attributes::OnOff::Id)
         {
             // led.Set(aEvent->value);
             matter_driver_led_set_onoff(aEvent->value);
         }
         break;
-    case ZCL_LEVEL_CONTROL_CLUSTER_ID:
-        if(path.mAttributeId == ZCL_CURRENT_LEVEL_ATTRIBUTE_ID)
+    case Clusters::LevelControl::Id:
+        if(path.mAttributeId == Clusters::LevelControl::Attributes::CurrentLevel::Id)
         {
             // led.SetBrightness(aEvent->value);
             matter_driver_led_set_brightness(aEvent->value);
         }
         break;
-    case ZCL_IDENTIFY_CLUSTER_ID:
+    case Clusters::Identify::Id:
         break;
     }
 


### PR DESCRIPTION
- fix compile error when building porting layer light example
- due to update in matter sdk, certain cluster and attribute id files are removed