### PR TITLE
[factorydata] return error when factorydata length is more than 2kb

### DIFF
--- a/component/common/application/matter/common/port/matter_utils.c
+++ b/component/common/application/matter/common/port/matter_utils.c
@@ -250,6 +250,14 @@ int32_t ReadFactory(uint8_t *buffer, uint16_t *pfactorydata_len)
     ret = flash_stream_read(&flash, address, length_bytes, pfactorydata_len);
     device_mutex_unlock(RT_DEV_LOCK_FLASH);
 
+    // Check if factory data length is more than 2048
+    // Which indicates that factory data is not flashed
+    // Return to prevent reading from non-existent address
+    if(*pfactorydata_len > 2048)
+    {
+        return -1;
+    }
+
     // +2 offset to read the FactoryData
     device_mutex_lock(RT_DEV_LOCK_FLASH);
     ret = flash_stream_read(&flash, address+2, *pfactorydata_len, buffer);


### PR DESCRIPTION
- check if factorydata length is more than 2048
- if it is more than 2048, this means factorydata is not flashed
- NOR flash default value is 0xffff, which might cause it to read 0xffff length of data
- return to prevent reading from non-existent address