### PR TITLE
[wifi] return pointer to matter_userdata

### DIFF
--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -148,9 +148,9 @@ void matter_scan_networks_with_ssid(const unsigned char *ssid, size_t length)
     }
 }
 
-void matter_get_scan_results(rtw_scan_result_t *result_buf, uint8_t scanned_num)
+rtw_scan_result_t *matter_get_scan_results()
 {
-    memcpy(result_buf, matter_userdata, sizeof(rtw_scan_result_t) * scanned_num);
+    return matter_userdata;
 }
 
 static int matter_find_ap_from_scan_buf(char*buf, int buflen, char *target_ssid, void *user_data)

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -25,7 +25,7 @@ typedef int (*chip_connmgr_callback)(void *object);
 void chip_connmgr_set_callback_func(chip_connmgr_callback p, void *data);
 void matter_scan_networks(void);
 void matter_scan_networks_with_ssid(const unsigned char *ssid, size_t length);
-void matter_get_scan_results(rtw_scan_result_t *result_buf, uint8_t scanned_num);
+rtw_scan_result_t *matter_get_scan_results(void);
 int matter_wifi_connect(
     char              *ssid,
     rtw_security_t    security_type,


### PR DESCRIPTION
- during wifi scan, instead of memcpying the matter_userdata into the pointer passed in, just return matter_userdata