### PR TITLE
[factorydata] enable transitional commissionabledataprovider

### DIFF
--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -253,7 +253,7 @@ GENERATE_NINJA:
 	echo chip_build_libshell = "true" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_inet_config_enable_ipv4 = "false" >> $(OUTPUT_DIR)/args.gn && \
 	echo chip_support_enable_storage_api_audit = "false" >> $(OUTPUT_DIR)/args.gn && \
-	echo chip_use_transitional_commissionable_data_provider = "false" >> $(OUTPUT_DIR)/args.gn && \
+	echo chip_use_transitional_commissionable_data_provider = "true" >> $(OUTPUT_DIR)/args.gn && \
 	sed -i 's/chip_build_tests\ =\ true/chip_build_tests\ =\ false/g' $(CHIPDIR)/config/ameba/args.gni && \
 	mkdir -p $(CHIPDIR)/config/ameba/components/chip && \
 	cd $(CHIPDIR)/config/ameba/components/chip && gn gen --check --fail-on-unused-args $(CHIPDIR)/examples/all-clusters-app/ameba/build/chip && \


### PR DESCRIPTION
- fallback to use this if reading factorydata fails