### PR TITLE
[wifi] remove storing wifi into dct during wifi_connect

### DIFF
--- a/component/common/api/wifi/wifi_conf.c
+++ b/component/common/api/wifi/wifi_conf.c
@@ -14,10 +14,6 @@
 #include <osdep_service.h>
 #include <device_lock.h>
 
-#if CONFIG_EXAMPLE_MATTER
-#include "chip_porting.h"
-#endif
-
 #if CONFIG_EXAMPLE_WLAN_FAST_CONNECT || CONFIG_JD_SMART
 #include "wlan_fast_connect/example_wlan_fast_connect.h"
 #if defined(CONFIG_FAST_DHCP) && CONFIG_FAST_DHCP
@@ -992,18 +988,6 @@ int wifi_connect(
 	}
 
 	result = RTW_SUCCESS;
-
-    // we store the wifi ssid and password in dct
-    // because for Matter onnetwork commissioning,
-    // these won't be added to network lists and won't be persisted
-#if CONFIG_EXAMPLE_MATTER
-    // these keys need to match exactly the same keys in matter sdk, AmebaUtils.cpp
-    const char kWiFiSSIDKeyName[]        = "wifi-ssid";
-    const char kWiFiCredentialsKeyName[] = "wifi-pass";
-
-    setPref_new(kWiFiSSIDKeyName, kWiFiSSIDKeyName, (uint8_t*) ssid, ssid_len);
-    setPref_new(kWiFiCredentialsKeyName, kWiFiCredentialsKeyName, (uint8_t*) password, password_len);
-#endif
 
 #if CONFIG_LWIP_LAYER
 #if defined(CONFIG_MBED_ENABLED) || defined(CONFIG_PLATFOMR_CUSTOMER_RTOS)

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -255,6 +255,11 @@ int matter_wifi_connect(
     return err;
 }
 
+int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting)
+{
+    return wifi_get_setting((u8*)WLAN0_NAME, pSetting);
+}
+
 int matter_wifi_disconnect(void)
 {
     return wifi_disconnect();

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -34,6 +34,7 @@ int matter_wifi_connect(
     int               password_len,
     int               key_id,
     void              *semaphore);
+int matter_get_sta_wifi_info(rtw_wifi_setting_t *pSetting);
 int matter_wifi_disconnect(void);
 int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);


### PR DESCRIPTION
- wifi info will be stored upon successful commissioning, handled by matter code
- add new API for matter to get wifi ssid and password
- fix #91 