### PR TITLE
[portinglayer] add identify cluster on endpoint 1

### DIFF
--- a/component/common/application/matter/example/light/example_matter_light.cpp
+++ b/component/common/application/matter/example/light/example_matter_light.cpp
@@ -10,6 +10,43 @@
 #include "matter_core.h"
 #include "matter_drivers.h"
 #include "matter_interaction.h"
+#include <app/clusters/identify-server/identify-server.h>
+
+void OnIdentifyStart(Identify *)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStart");
+}
+
+void OnIdentifyStop(Identify *)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStop");
+}
+
+void OnTriggerEffect(Identify * identify)
+{
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
+        break;
+    default:
+        ChipLogProgress(Zcl, "No identifier effect");
+        return;
+    }
+}
+
+static Identify gIdentify1 = {
+    chip::EndpointId{ 1 }, OnIdentifyStart, OnIdentifyStop, EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, OnTriggerEffect,
+};
 
 static void example_matter_light_task(void *pvParameters)
 {

--- a/component/common/application/matter/example/light/example_matter_light.cpp
+++ b/component/common/application/matter/example/light/example_matter_light.cpp
@@ -10,43 +10,6 @@
 #include "matter_core.h"
 #include "matter_drivers.h"
 #include "matter_interaction.h"
-#include <app/clusters/identify-server/identify-server.h>
-
-void OnIdentifyStart(Identify *)
-{
-    ChipLogProgress(Zcl, "OnIdentifyStart");
-}
-
-void OnIdentifyStop(Identify *)
-{
-    ChipLogProgress(Zcl, "OnIdentifyStop");
-}
-
-void OnTriggerEffect(Identify * identify)
-{
-    switch (identify->mCurrentEffectIdentifier)
-    {
-    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
-        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
-        break;
-    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
-        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
-        break;
-    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
-        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
-        break;
-    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
-        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
-        break;
-    default:
-        ChipLogProgress(Zcl, "No identifier effect");
-        return;
-    }
-}
-
-static Identify gIdentify1 = {
-    chip::EndpointId{ 1 }, OnIdentifyStart, OnIdentifyStop, EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, OnTriggerEffect,
-};
 
 static void example_matter_light_task(void *pvParameters)
 {

--- a/component/common/application/matter/example/light/matter_drivers.cpp
+++ b/component/common/application/matter/example/light/matter_drivers.cpp
@@ -16,6 +16,11 @@ using namespace ::chip::app;
 MatterLED led;
 gpio_irq_t gpio_btn;
 
+// Set identify cluster and its callback on ep1
+static Identify gIdentify1 = {
+    chip::EndpointId{ 1 }, matter_driver_on_identify_start, matter_driver_on_identify_stop, EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, matter_driver_on_trigger_effect,
+};
+
 void matter_driver_button_callback(uint32_t id, gpio_irq_event event)
 {
     AppEvent downlink_event;
@@ -70,6 +75,38 @@ exit:
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
     }
     return err;
+}
+
+void matter_driver_on_identify_start(Identify * identify)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStart");
+}
+
+void matter_driver_on_identify_stop(Identify * identify)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStop");
+}
+
+void matter_driver_on_trigger_effect(Identify * identify)
+{
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
+        break;
+    default:
+        ChipLogProgress(Zcl, "No identifier effect");
+        return;
+    }
 }
 
 void matter_driver_uplink_update_handler(AppEvent *aEvent)

--- a/component/common/application/matter/example/light/matter_drivers.h
+++ b/component/common/application/matter/example/light/matter_drivers.h
@@ -3,9 +3,13 @@
 #include "matter_events.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <app/clusters/identify-server/identify-server.h>
 
 CHIP_ERROR matter_driver_button_init(void);
 CHIP_ERROR matter_driver_led_init(void);
 CHIP_ERROR matter_driver_led_set_startup_value(void);
+void matter_driver_on_identify_start(Identify * identify);
+void matter_driver_on_identify_stop(Identify * identify);
+void matter_driver_on_trigger_effect(Identify * identify);
 void matter_driver_uplink_update_handler(AppEvent * event);
 void matter_driver_downlink_update_handler(AppEvent *aEvent);


### PR DESCRIPTION
- without this, the chip-tool will return INVALID_COMMAND when running `chip-tool identify trigger-effect 0 0 1 1`
- this adds the identify cluster on ep1 and also add some handlers for stop, start and triggereffect