### PR TITLE
[shell] matter shell using loguart support

### DIFF
--- a/component/common/application/matter/common/atcmd/atcmd_matter.c
+++ b/component/common/application/matter/common/atcmd/atcmd_matter.c
@@ -16,6 +16,9 @@ extern void amebaApplyUpdateCmdHandler();
 #endif
 #endif
 
+// Queue for matter shell
+QueueHandle_t shell_queue;
+
 void fATchipapp(void *arg)
 {
 	/* To avoid gcc warnings */
@@ -55,18 +58,32 @@ void fATchipapp2(void *arg)
 #endif
 }
 
+void fATmattershell(void *arg)
+{
+    if (arg != NULL)
+    {
+        xQueueSend(shell_queue, arg, pdMS_TO_TICKS(10));
+    }
+    else
+    {
+        printf("No arguments provided for matter shell\r\n");
+    } 
+}
+
 log_item_t at_matter_items[] = {
 #ifndef CONFIG_INIC_NO_FLASH
 #if ATCMD_VER == ATVER_1
-	{"ATS$", fATchipapp, {NULL,NULL}},
-	{"ATS%", fATchipapp1, {NULL, NULL}},
-	{"ATS^", fATchipapp2, {NULL, NULL}},
+	{"ATM$", fATchipapp, {NULL,NULL}},
+	{"ATM%", fATchipapp1, {NULL, NULL}},
+	{"ATM^", fATchipapp2, {NULL, NULL}},
+    {"ATMS", fATmattershell, {NULL, NULL}},
 #endif // end of #if ATCMD_VER == ATVER_1
 #endif
 };
 
 void at_matter_init(void)
 {
+    shell_queue = xQueueCreate(3, 256); // backlog 3 commands max
 	log_service_add_table(at_matter_items, sizeof(at_matter_items)/sizeof(at_matter_items[0]));
 }
 


### PR DESCRIPTION
- fix #26 
- use atcmd for matter shell commands
- matter atcmd starts with `ATM` prefix
- eg usage for matter shell commands: 
    - `ATMS=help`
    - `ATMS=device factoryreset`