### PR TITLE
[portinglayer] Implement error mapping support for matter sdk

### DIFF
--- a/component/common/application/matter/common/port/chip_porting.h
+++ b/component/common/application/matter/common/port/chip_porting.h
@@ -17,6 +17,7 @@ extern "C" {
 #include <stddef.h> /* for size_t */
 #include <stdarg.h>
 #include <platform_opts_bt.h>
+#include <dct.h>
 
 #if defined(CONFIG_BT_MATTER_ADAPTER) && CONFIG_BT_MATTER_ADAPTER
 /** @brief  Config local address type: 0-pulic address, 1-static random address, 2-random resolvable private address */

--- a/component/common/application/matter/common/port/matter_dcts.c
+++ b/component/common/application/matter/common/port/matter_dcts.c
@@ -648,7 +648,7 @@ exit:
 s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSize, size_t *outLen)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules

--- a/component/common/application/matter/common/port/matter_dcts.c
+++ b/component/common/application/matter/common/port/matter_dcts.c
@@ -281,7 +281,7 @@ exit:
     return ret;
 }
 
-s32 checkExist(const char *domain, const char *key)
+bool checkExist(const char *domain, const char *key)
 {
     dct_handle_t handle;
     s32 ret;
@@ -346,7 +346,7 @@ s32 checkExist(const char *domain, const char *key)
 
 exit:
     free(str);
-    return ret;
+    return (ret == DCT_SUCCESS) ? true : false;
 }
 
 s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount)

--- a/component/common/application/matter/common/port/matter_dcts.c
+++ b/component/common/application/matter/common/port/matter_dcts.c
@@ -112,13 +112,13 @@ s32 initPref(void)
 {
     s32 ret;
     ret = dct_init(DCT_BEGIN_ADDR_MATTER, MODULE_NUM, VARIABLE_NAME_SIZE, VARIABLE_VALUE_SIZE, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_init failed with error: %d\n", ret);
     else
         printf("dct_init success\n");
 
     ret = dct_init2(DCT_BEGIN_ADDR_MATTER2, MODULE_NUM2, VARIABLE_NAME_SIZE2, VARIABLE_VALUE_SIZE2, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_init2 failed with error: %d\n", ret);
     else
         printf("dct_init2 success\n");
@@ -136,13 +136,13 @@ s32 deinitPref(void)
 {
     s32 ret;
     ret = dct_format(DCT_BEGIN_ADDR_MATTER, MODULE_NUM, VARIABLE_NAME_SIZE, VARIABLE_VALUE_SIZE, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_format failed with error: %d\n", ret);
     else
         printf("dct_format success\n");
 
     ret = dct_format2(DCT_BEGIN_ADDR_MATTER2, MODULE_NUM2, VARIABLE_NAME_SIZE2, VARIABLE_VALUE_SIZE2, ENABLE_BACKUP, ENABLE_WEAR_LEVELING);
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("dct_format2 failed with error: %d\n", ret);
     else
         printf("dct_format2 success\n");
@@ -164,14 +164,14 @@ s32 registerPref()
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_register_module(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_register_module %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT1 modules registration failed");
     return ret;
 }
@@ -185,14 +185,14 @@ s32 registerPref2()
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_register_module2(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_register_module2 %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT2 modules registration failed");
     return ret;
 }
@@ -206,14 +206,14 @@ s32 clearPref()
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_unregister_module(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_unregister_module %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT1 modules unregistration failed");
     return ret;
 }
@@ -227,14 +227,14 @@ s32 clearPref2()
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_unregister_module2(ns);
-        if (ret != 0)
+        if (ret != DCT_SUCCESS)
             goto exit;
         else
             printf("dct_unregister_module2 %s success\n", ns);
     }
 
 exit:
-    if (ret != 0)
+    if (ret != DCT_SUCCESS)
         printf("DCT2 modules unregistration failed");
     return ret;
 }
@@ -242,7 +242,7 @@ exit:
 s32 deleteKey(const char *domain, const char *key)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules
@@ -250,14 +250,14 @@ s32 deleteKey(const char *domain, const char *key)
     {
         snprintf(ns, 15, "matter_kvs1_%d", i+1); 
         ret = dct_open_module(&handle, ns);
-        if (DCT_SUCCESS != ret)
+        if (ret != DCT_SUCCESS)
         {
             printf("%s : dct_open_module(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
         ret = dct_delete_variable(&handle, key);
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret != DCT_SUCCESS)
             return ret;
     }
 
@@ -266,14 +266,14 @@ s32 deleteKey(const char *domain, const char *key)
     {
         snprintf(ns, 15, "matter_kvs2_%d", i+1); 
         ret = dct_open_module2(&handle, ns);
-        if (DCT_SUCCESS != ret)
+        if (ret != DCT_SUCCESS)
         {
             printf("%s : dct_open_module2(%s) failed with error: %d\n" ,__FUNCTION__, ns, ret);
             goto exit;
         }
         ret = dct_delete_variable2(&handle, key);
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret != DCT_SUCCESS)
             return ret;
     }
 
@@ -281,10 +281,10 @@ exit:
     return ret;
 }
 
-bool checkExist(const char *domain, const char *key)
+s32 checkExist(const char *domain, const char *key)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = 0;
     u8 *str = malloc(sizeof(u8) * VARIABLE_VALUE_SIZE2); // use the bigger buffer size
     char ns[15];
@@ -306,8 +306,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         len = sizeof(u64);
@@ -316,8 +315,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         dct_close_module(&handle);
@@ -340,8 +338,7 @@ bool checkExist(const char *domain, const char *key)
         {
             printf("checkExist key=%s found.\n", key);
             dct_close_module2(&handle);
-            free(str);
-            return true;
+            goto exit;
         }
 
         dct_close_module2(&handle);
@@ -349,15 +346,14 @@ bool checkExist(const char *domain, const char *key)
 
 exit:
     free(str);
-    return false;
+    return ret;
 }
 
 s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
-    bool set_success = false;
 
     if (byteCount <= 64)
     {
@@ -379,13 +375,12 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 #else
                 ret = dct_set_variable_new(&handle, key, (char *)value, (uint16_t)byteCount);
 #endif
-                if (DCT_SUCCESS != ret)
+                if (ret != DCT_SUCCESS)
                 {
                     printf("%s : dct_set_variable(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
                     dct_close_module(&handle);
                     goto exit;
                 }
-                set_success = true;
                 dct_close_module(&handle);
                 break;
             }
@@ -412,13 +407,12 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
 #else
                 ret = dct_set_variable_new2(&handle, key, (char *)value, (uint16_t)byteCount);
 #endif
-                if (DCT_SUCCESS != ret)
+                if (ret != DCT_SUCCESS)
                 {
                     printf("%s : dct_set_variable2(%s) failed with error: %d\n" ,__FUNCTION__, key, ret);
                     dct_close_module2(&handle);
                     goto exit;
                 }
-                set_success = true;
                 dct_close_module2(&handle);
                 break;
             }
@@ -427,13 +421,13 @@ s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount
     }
 
 exit:
-    return (set_success == true ? 1 : 0);
+    return ret;
 }
 
 s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u8);
     char ns[15];
 
@@ -453,7 +447,7 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -475,7 +469,7 @@ s32 getPref_bool_new(const char *domain, const char *key, u8 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -488,7 +482,7 @@ exit:
 s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u32);
     char ns[15];
 
@@ -508,7 +502,7 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -530,7 +524,7 @@ s32 getPref_u32_new(const char *domain, const char *key, u32 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -543,7 +537,7 @@ exit:
 s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     uint16_t len = sizeof(u64);
     char ns[15];
 
@@ -563,7 +557,7 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
         ret = dct_get_variable_new(&handle, key, (char *)val, &len);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -585,7 +579,7 @@ s32 getPref_u64_new(const char *domain, const char *key, u64 *val)
         ret = dct_get_variable_new2(&handle, key, (char *)val, &len);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             return ret;
         }
@@ -598,7 +592,7 @@ exit:
 s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufSize, size_t *outLen)
 {
     dct_handle_t handle;
-    s32 ret = -1;
+    s32 ret;
     char ns[15];
 
     // Loop over DCT1 modules
@@ -617,7 +611,7 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
         ret = dct_get_variable_new(&handle, key, buf, &bufSize);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -640,7 +634,7 @@ s32 getPref_str_new(const char *domain, const char *key, char * buf, size_t bufS
         ret = dct_get_variable_new2(&handle, key, buf, &bufSize);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -673,7 +667,7 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
         ret = dct_get_variable_new(&handle, key, (char *)buf, &bufSize);
 #endif
         dct_close_module(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;
@@ -696,7 +690,7 @@ s32 getPref_bin_new(const char *domain, const char *key, u8 * buf, size_t bufSiz
         ret = dct_get_variable_new2(&handle, key, (char *)buf, &bufSize);
 #endif
         dct_close_module2(&handle);
-        if (DCT_SUCCESS == ret)
+        if (ret == DCT_SUCCESS)
         {
             *outLen = bufSize;
             return ret;

--- a/component/common/application/matter/common/port/matter_dcts.h
+++ b/component/common/application/matter/common/port/matter_dcts.h
@@ -19,7 +19,7 @@ s32 registerPref2(void);
 s32 clearPref(void);
 s32 clearPref2(void);
 s32 deleteKey(const char *domain, const char *key);
-bool checkExist(const char *domain, const char *key);
+s32 checkExist(const char *domain, const char *key);
 s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount);
 s32 getPref_bool_new(const char *domain, const char *key, u8 *val);
 s32 getPref_u32_new(const char *domain, const char *key, u32 *val);

--- a/component/common/application/matter/common/port/matter_dcts.h
+++ b/component/common/application/matter/common/port/matter_dcts.h
@@ -19,7 +19,7 @@ s32 registerPref2(void);
 s32 clearPref(void);
 s32 clearPref2(void);
 s32 deleteKey(const char *domain, const char *key);
-s32 checkExist(const char *domain, const char *key);
+bool checkExist(const char *domain, const char *key);
 s32 setPref_new(const char *domain, const char *key, u8 *value, size_t byteCount);
 s32 getPref_bool_new(const char *domain, const char *key, u8 *val);
 s32 getPref_u32_new(const char *domain, const char *key, u32 *val);

--- a/component/common/application/matter/common/port/matter_timers.c
+++ b/component/common/application/matter/common/port/matter_timers.c
@@ -134,7 +134,7 @@ long long matter_rtc_read()
 
 void matter_rtc_write(long long time)
 {
-    rtc_write(time)
+    rtc_write(time);
 }
 
 #ifdef __cplusplus

--- a/component/common/application/matter/common/port/matter_timers.c
+++ b/component/common/application/matter/common/port/matter_timers.c
@@ -13,6 +13,7 @@
 #include "errno.h"
 #include "FreeRTOS.h"
 #include "chip_porting.h"
+#include "rtc_api.h"
 
 #define MICROSECONDS_PER_SECOND    ( 1000000LL )                                   /**< Microseconds per second. */
 #define NANOSECONDS_PER_SECOND     ( 1000000000LL )                                /**< Nanoseconds per second. */
@@ -119,6 +120,21 @@ int _vTaskDelay( const TickType_t xTicksToDelay )
     vTaskDelay(xTicksToDelay);
 
     return 0;
+}
+
+void matter_rtc_init()
+{
+    rtc_init();
+}
+
+long long matter_rtc_read()
+{
+    return rtc_read();
+}
+
+void matter_rtc_write(long long time)
+{
+    rtc_write(time)
 }
 
 #ifdef __cplusplus

--- a/component/common/application/matter/common/port/matter_timers.h
+++ b/component/common/application/matter/common/port/matter_timers.h
@@ -16,6 +16,9 @@ typedef u32 TickType_t;
 int _nanosleep( const struct timespec * rqtp, struct timespec * rmtp );
 int _vTaskDelay( const TickType_t xTicksToDelay );
 time_t _time( time_t * tloc );
+void matter_rtc_init(void);
+long long matter_rtc_read(void);
+void matter_rtc_write(long long time);
 
 #ifdef __cplusplus
 }

--- a/component/common/application/matter/common/port/matter_utils.c
+++ b/component/common/application/matter/common/port/matter_utils.c
@@ -268,7 +268,7 @@ int32_t ReadFactory(uint8_t *buffer, uint16_t *pfactorydata_len)
 
 int32_t DecodeFactory(uint8_t *buffer, FactoryData *fdp, uint16_t data_len)
 {
-    int32_t ret = 0;
+    int32_t ret = 1;
     pb_istream_t stream;
     FactoryDataProvider FDP = FactoryDataProvider_init_zero;
 

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -325,6 +325,16 @@ int matter_wifi_get_rssi(int *prssi)
     return wifi_get_rssi(prssi);
 }
 
+int matter_wifi_get_mac_address(char *mac)
+{
+    return wifi_get_mac_address(mac);
+}
+
+int matter_wifi_get_last_error()
+{
+    return wifi_get_last_error();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -280,7 +280,7 @@ int matter_wifi_is_connected_to_ap(void)
     return wifi_is_connected_to_ap();
 }
 
-uint8_t matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state)
+void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state)
 {
     if (dhcp_state == DHCP_START)
     {

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -292,6 +292,39 @@ void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state)
     }
 }
 
+int matter_wifi_get_ap_bssid(unsigned char *bssid)
+{
+    return wifi_get_ap_bssid(bssid);
+}
+
+int matter_wifi_get_network_mode(rtw_network_mode_t *pmode)
+{
+    return wifi_get_network_mode(pmode);
+}
+
+int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase)
+{
+    if (wext_get_enc_ext(ifname, alg, key_idx, passphrase) < 0)
+    {
+        return RTW_ERROR;
+    }
+    return RTW_SUCCESS;
+}
+
+int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch)
+{
+    if (wext_get_channel(ifname, ch) < 0)
+    {
+        return RTW_ERROR;
+    }
+    return RTW_SUCCESS;
+}
+
+int matter_wifi_get_rssi(int *prssi)
+{
+    return wifi_get_rssi(prssi);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -280,16 +280,19 @@ int matter_wifi_is_connected_to_ap(void)
     return wifi_is_connected_to_ap();
 }
 
-void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state)
+void matter_lwip_dhcp()
 {
-    if (dhcp_state == DHCP_START)
-    {
-        LwIP_DHCP(0, DHCP_START);
-    }
-    else if (dhcp_state == DHCP6_START)
-    {
-        LwIP_DHCP6(0, DHCP6_START);
-    }
+    LwIP_DHCP(0, DHCP_START);
+}
+
+void matter_lwip_dhcp6(void)
+{
+    LwIP_DHCP6(0, DHCP6_START);
+}
+
+void matter_lwip_releaseip(void)
+{
+    LwIP_ReleaseIP(0);
 }
 
 int matter_wifi_get_ap_bssid(unsigned char *bssid)

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -40,6 +40,11 @@ int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);
 int matter_wifi_is_connected_to_ap(void);
 void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state);
+int matter_wifi_get_ap_bssid(unsigned char*);
+int matter_wifi_get_network_mode(rtw_network_mode_t *pmode);
+int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
+int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
+int matter_wifi_get_rssi(int *prssi);
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -39,7 +39,7 @@ int matter_wifi_disconnect(void);
 int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);
 int matter_wifi_is_connected_to_ap(void);
-uint8_t matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state);
+void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state);
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -45,6 +45,8 @@ int matter_wifi_get_network_mode(rtw_network_mode_t *pmode);
 int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
 int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
 int matter_wifi_get_rssi(int *prssi);
+int matter_wifi_get_mac_address(char *mac);
+int matter_wifi_get_last_error(void);
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_wifis.h
+++ b/component/common/application/matter/common/port/matter_wifis.h
@@ -39,7 +39,9 @@ int matter_wifi_disconnect(void);
 int matter_wifi_on(rtw_mode_t mode);
 int matter_wifi_set_mode(rtw_mode_t mode);
 int matter_wifi_is_connected_to_ap(void);
-void matter_lwip_dhcp(uint8_t idx, uint8_t dhcp_state);
+void matter_lwip_dhcp(void);
+void matter_lwip_dhcp6(void);
+void matter_lwip_releaseip(void);
 int matter_wifi_get_ap_bssid(unsigned char*);
 int matter_wifi_get_network_mode(rtw_network_mode_t *pmode);
 int matter_wifi_get_security_type(const char *ifname, uint16_t *alg, uint8_t *key_idx, uint8_t *passphrase);
@@ -47,6 +49,7 @@ int matter_wifi_get_wifi_channel_number(const char *ifname, uint8_t *ch);
 int matter_wifi_get_rssi(int *prssi);
 int matter_wifi_get_mac_address(char *mac);
 int matter_wifi_get_last_error(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -190,6 +190,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -190,6 +190,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -185,6 +185,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -187,6 +187,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -187,6 +187,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -187,6 +187,8 @@ SRC_C += $(CHIPDIR)/examples/platform/ameba/route_hook/ameba_route_table.c
 
 SRC_CPP = 
 
+SRC_CPP += $(CHIPDIR)/src/app/server/AclStorage.cpp
+SRC_CPP += $(CHIPDIR)/src/app/server/DefaultAclStorage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/EchoHandler.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/Dnssd.cpp
 SRC_CPP += $(CHIPDIR)/src/app/server/OnboardingCodesUtil.cpp


### PR DESCRIPTION
### Error mapping
- Standardize return types for below api
  - wifi
  - dct
  - flash
- The real mapping happens inside AmebaUtils in matter sdk
- Added timer related api
- Added more wifi related api

### DHCP split into ipv4 and ipv6
- run dhcp for both ipv4 and ipv6
- matter will call release ip api on disconnect

### Build
- add AclStorage and DefaultAclStorage