### PR TITLE
[mbedtls] fix mbedtls error when hw crypto is disabled

### DIFF
--- a/component/common/application/matter/common/mbedtls/mbedtls_config.h
+++ b/component/common/application/matter/common/mbedtls/mbedtls_config.h
@@ -35,7 +35,7 @@
 #endif
 
 #define RTL_HW_CRYPTO
-//#define SUPPORT_HW_SW_CRYPTO
+#define SUPPORT_HW_SW_CRYPTO
 
 #define MBEDTLS_PLATFORM_SNPRINTF_MACRO snprintf
 


### PR DESCRIPTION
* Enable SUPPORT_HW_SW_CRYPTO to avoid mbedtls error when use_hw_crypto_func is set to 0

Notes:
* On default define both RTL_HW_CRYPTO and SUPPORT_HW_SW_CRYPTO, and will use HW crypto (rom_ssl_ram_map.use_hw_crypto_func = 1)
* Customer can decide to use HW or SW crypto by setting rom_ssl_ram_map.use_hw_crypto_func in platform_set_malloc_free()