### PR TITLE
[ble] Add ble_matter_adapter and support multiple adv

### DIFF
--- a/component/common/application/matter/common/bluetooth/matter_blemgr_common.c
+++ b/component/common/application/matter/common/bluetooth/matter_blemgr_common.c
@@ -1,0 +1,175 @@
+#include <platform_opts_bt.h>
+#if defined(CONFIG_BLE_MATTER_ADAPTER) && CONFIG_BLE_MATTER_ADAPTER
+#include "string.h"
+#include "gap.h"
+#include "gap_le.h"
+#include "os_mem.h"
+#include "gap_le.h"
+#include "gap_adv.h"
+#include "gap_conn_le.h"
+#include "platform_stdlib.h"
+#include "os_sync.h"
+#include "os_sched.h"
+#include "os_timer.h"
+#include "matter_blemgr_common.h"
+#include "ble_matter_adapter_app_main.h"
+#include "ble_matter_adapter_app_flags.h"
+#include "ble_matter_adapter_app.h"
+#include "os_sched.h"
+
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+#define MAX_ADV_NUMBER 2
+
+uint8_t matter_adv_id = MAX_ADV_NUMBER;
+uint16_t matter_adv_interval = 0;
+uint16_t matter_adv_int_min = 0x20;
+uint16_t matter_adv_int_max = 0x20;
+uint8_t matter_adv_data_length = 0;
+uint8_t matter_adv_data[31] = {0};
+uint8_t customer_adv_data[] = {0x02, 0x01, 0x05, 0x03, 0x03, 0x0A, 0xA0, 0x0D,0x09, 'B', 'L', 'E', '_', 'C', 'U', 'S', 'T', 'O', 'M', 'E', 'R'};
+uint8_t customer_rsp_data[] = {0x03, 0x19, 0x00,0x00};
+uint8_t customer_adv_data_length = sizeof(customer_adv_data);
+uint8_t customer_rsp_data_length = sizeof(customer_rsp_data);
+matter_blemgr_callback matter_blemgr_callback_func = NULL;
+void *matter_blemgr_callback_data = NULL;
+
+extern T_MULTI_ADV_CONCURRENT matter_multi_adapter; //app.c
+extern int ble_matter_adapter_peripheral_app_max_links; //app.c
+extern uint8_t customer_adv_id;
+extern T_SERVER_ID ble_matter_adapter_service_id;
+
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+extern void ble_matter_adapter_multi_adv_init();
+int matter_blemgr_init(void) {
+	ble_matter_adapter_app_init();
+	ble_matter_adapter_multi_adv_init();
+	return 0;
+}
+
+void matter_blemgr_set_callback_func(matter_blemgr_callback p, void *data) {
+	matter_blemgr_callback_func = p;
+	matter_blemgr_callback_data = data;
+}
+
+extern bool matter_multi_adv_start_by_id(uint8_t *adv_id, uint8_t *adv_data, uint16_t adv_len, uint8_t *rsp_data, uint16_t rsp_len, uint8_t type);
+int matter_blemgr_start_adv(void) {
+	bool result = 0;
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	result = matter_multi_adv_start_by_id(&matter_adv_id, matter_adv_data, matter_adv_data_length, NULL, 0, 1); // the last parameter 0: Matter 1: Customer
+	if (result == 1)
+		return 1;
+	result = matter_multi_adv_start_by_id(&customer_adv_id, customer_adv_data, customer_adv_data_length, customer_rsp_data, customer_rsp_data_length, 2);
+	if (result == 1)
+		return 1;
+#endif
+	return 0;
+}
+
+extern bool matter_multi_adv_stop_by_id(uint8_t *adv_id);
+int matter_blemgr_stop_adv(void) {
+	bool result = 0;
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	if (matter_multi_adapter.matter_sta_sto_flag != false) {
+		printf("[%s]adv already stop...\r\n", __func__);
+		return 1;
+	}
+
+	result = matter_multi_adv_stop_by_id(&matter_adv_id);
+	if (result == 1)
+		return 1;
+	matter_multi_adapter.matter_sta_sto_flag = true;
+#endif
+	return 0;
+}
+
+int matter_blemgr_config_adv(uint16_t adv_int_min, uint16_t adv_int_max, uint8_t *adv_data, uint8_t adv_data_length) {
+	matter_adv_interval = adv_int_max;
+	matter_adv_int_min = adv_int_min;
+	matter_adv_int_max = adv_int_max;
+	matter_adv_data_length = adv_data_length;
+	memcpy(matter_adv_data, adv_data, adv_data_length);
+
+	return 0;
+}
+
+uint16_t matter_blemgr_get_mtu(uint8_t connect_id) {
+	int ret;
+	uint16_t mtu_size;
+
+	if (ble_matter_adapter_peripheral_app_max_links == 0) {
+		printf("[%s]matter as slave, no connection\r\n", __func__);
+		return 1;
+	}
+	ret = le_get_conn_param(GAP_PARAM_CONN_MTU_SIZE, &mtu_size, connect_id);
+	if (ret == 0)
+	{
+		printf("printing MTU size\r\n");
+		return mtu_size;
+	}
+	else
+		return 0;
+}
+
+int matter_blemgr_set_device_name(char *device_name, uint8_t device_name_length) {
+	if (device_name == NULL || device_name_length > GAP_DEVICE_NAME_LEN) {
+		printf("[%s]:invalid name or len:name 0x%x,len %d\r\n",__func__, device_name, device_name_length);
+		return 1;
+	}
+	le_set_gap_param(GAP_PARAM_DEVICE_NAME, device_name_length, device_name);
+
+	return 0;
+
+}
+
+int matter_blemgr_disconnect(uint8_t connect_id) {
+	if (connect_id >= BLE_MATTER_ADAPTER_APP_MAX_LINKS) {
+		printf("[%s]:invalid conn_hdl[%d]\r\n", __func__, connect_id);
+		return 1;
+	}
+	T_GAP_DEV_STATE new_state;
+	uint8_t *conn_id = (uint8_t *)os_mem_alloc(0, sizeof(uint8_t));
+	*conn_id = connect_id;
+
+	if ((ble_matter_adapter_app_send_api_msg(5, conn_id)) == false) {
+		printf("[%s] send msg fail\r\n", __func__);
+		os_mem_free(conn_id);
+		return 1;
+	}
+	return 0;
+}
+
+int matter_blemgr_send_indication(uint8_t connect_id, uint8_t *data, uint16_t data_length) {
+
+	if (connect_id >= BLE_MATTER_ADAPTER_APP_MAX_LINKS || data == NULL || data_length == 0) {
+		printf("[%s]:invalid param:conn_hdl %d,data 0x%x data_length 0x%x\r\n",__func__, connect_id, data, data_length);
+		return 1;
+	}
+	BT_MATTER_SERVER_SEND_DATA *indication_param = (BT_MATTER_SERVER_SEND_DATA *)os_mem_alloc(0, sizeof(BT_MATTER_SERVER_SEND_DATA));
+	if (indication_param)
+    	{
+        	indication_param->conn_id = connect_id;
+		indication_param->service_id = ble_matter_adapter_service_id;
+        	indication_param->attrib_index = BT_MATTER_ADAPTER_SERVICE_CHAR_TX_INDEX;
+		indication_param->data_len = data_length;
+		indication_param->type = GATT_PDU_TYPE_INDICATION;
+        	if (indication_param->data_len != 0)
+        	{
+            		indication_param->p_data = os_mem_alloc(0, indication_param->data_len);
+            		memcpy(indication_param->p_data, data, indication_param->data_len);
+        	}
+        	if (ble_matter_adapter_app_send_api_msg(4, indication_param) == false)
+        	{
+            		printf("[%s] os_mem_free\r\n");
+            		os_mem_free(indication_param->p_data);
+            		os_mem_free(indication_param);
+            		return 1;
+        	}
+    	}
+	return 0;
+}
+
+#endif

--- a/component/common/application/matter/common/bluetooth/matter_blemgr_common.h
+++ b/component/common/application/matter/common/bluetooth/matter_blemgr_common.h
@@ -6,7 +6,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
 typedef enum
 {
     MATTER_BLEMGR_GAP_CONNECT_CB,
@@ -55,14 +57,25 @@ typedef struct
 
 typedef int (*matter_blemgr_callback)(void *param, T_MATTER_BLEMGR_CALLBACK_TYPE cb_type, void *p_cb_data);
 
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
 int matter_blemgr_init(void);
+
 void matter_blemgr_set_callback_func(matter_blemgr_callback p, void *data);
+
 int matter_blemgr_start_adv(void);
+
 int matter_blemgr_stop_adv(void);
+
 int matter_blemgr_config_adv(uint16_t adv_int_min, uint16_t adv_int_max, uint8_t *adv_data, uint8_t adv_data_length);
+
 uint16_t matter_blemgr_get_mtu(uint8_t connect_id);
+
 int matter_blemgr_set_device_name(char *device_name, uint8_t device_name_length);
+
 int matter_blemgr_disconnect(uint8_t connect_id);
+
 int matter_blemgr_send_indication(uint8_t connect_id, uint8_t *data, uint16_t data_length);
 
 #ifdef __cplusplus

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.c
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.c
@@ -1,0 +1,2071 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      central_client_app.c
+   * @brief     This file handles BLE central application routines.
+   * @author    jane
+   * @date      2017-06-06
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+
+/*============================================================================*
+ *                              Header Files
+ *============================================================================*/
+#include <platform_opts_bt.h>
+#if defined(CONFIG_BLE_MATTER_ADAPTER) && CONFIG_BLE_MATTER_ADAPTER
+#include <stdio.h>
+#include <app_msg.h>
+#include <string.h>
+#include <trace_app.h>
+#include <gap_scan.h>
+#include <gap.h>
+#include <gap_adv.h>
+#include <gap_msg.h>
+#include <gap_bond_le.h>
+#include <gap_conn_le.h>
+#include <gcs_client.h>
+#include "gatt_builtin_services.h"
+#include "os_mem.h"
+#include "os_msg.h"
+#include "os_sync.h"
+#include "os_queue.h"
+#include <ble_matter_adapter_app_flags.h>
+#include <ble_matter_adapter_app.h>
+#include <ble_matter_adapter_app_task.h>
+#include "ble_matter_adapter_app_main.h"
+#if CONFIG_BLE_MATTER_MULTI_ADV
+#include "vendor_cmd_bt.h"
+#include "matter_blemgr_common.h"
+#include "os_timer.h"
+#endif
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+#define BLE_MATTER_ADAPTER_APP_MAX_DEVICE_INFO 6
+
+/*============================================================================*
+ *                              Variables
+ *============================================================================*/
+int bt_matter_device_matter_scan_state = 0;
+int ble_matter_adapter_peripheral_app_max_links = 0;
+int ble_matter_adapter_central_app_max_links = 0;
+
+T_GAP_DEV_STATE ble_matter_adapter_gap_dev_state = {0, 0, 0, 0, 0};                /**< GAP device state */
+T_APP_LINK ble_matter_adapter_app_link_table[BLE_MATTER_ADAPTER_APP_MAX_LINKS];
+
+T_CLIENT_ID ble_matter_adapter_gcs_client_id;         /**< General Common Services client client id*/
+T_SERVER_ID ble_matter_adapter_service_id;	/**< Matter service id */
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+M_MULTI_ADV_PARAM matter_multi_adv_param_array[MAX_ADV_NUMBER] = {0};
+T_MULTI_ADV_CONCURRENT matter_multi_adapter = {0};
+
+uint8_t matter_local_public_addr[6] = {0};
+uint8_t matter_local_static_random_addr[6] = {0};
+
+uint8_t link_customer = 0;    //1  means connection is matter   2 means connection is customer
+uint8_t customer_adv_id=2;
+uint8_t matter_multi_adv_bt_deinit_id=0xff;
+extern uint8_t matter_adv_id;
+
+extern matter_blemgr_callback matter_blemgr_callback_func;
+extern void *matter_blemgr_callback_data;
+
+extern uint16_t matter_adv_interval;
+extern uint16_t matter_adv_int_min;
+extern uint16_t matter_adv_int_max;
+extern uint8_t customer_adv_data[];
+extern uint8_t customer_rsp_data[];
+extern uint8_t customer_adv_data_length;
+extern uint8_t customer_rsp_data_length;
+extern uint8_t matter_adv_data[31];
+extern uint8_t matter_adv_data_length;
+extern bool matter_server_is_commissioned();
+
+#endif
+/*============================================================================*
+ *                              Multi ADV Functions
+ *============================================================================*/
+#if CONFIG_BLE_MATTER_MULTI_ADV
+uint8_t matter_get_unused_adv_index(void)
+{
+	int i;
+	for(i= 0; i < MAX_ADV_NUMBER; i++){
+		if(!matter_multi_adv_param_array[i].is_used)
+			return i;
+	}
+	return MAX_ADV_NUMBER;
+}
+
+//reserve for future use
+bool matter_multi_adv_stop_by_id(uint8_t *adv_id)
+{
+	if(*adv_id < 0 || *adv_id >= MAX_ADV_NUMBER){
+			printf("[%s] wrong input advId:%d\r\n",__func__, *adv_id);
+			return 1;
+	}	
+	if(!matter_multi_adv_param_array[*adv_id].is_used){
+		printf("[%s] adv id %d is already stop or not start\r\n",__func__, *adv_id);
+		return 1;
+	}
+
+	if(matter_multi_adv_param_array[*adv_id].one_shot_timer){
+		os_timer_delete(&matter_multi_adv_param_array[*adv_id].one_shot_timer);
+	}
+	if (matter_multi_adv_param_array[*adv_id].update_adv_mutex) {
+		os_mutex_delete(matter_multi_adv_param_array[*adv_id].update_adv_mutex);
+	}
+	memset(&matter_multi_adv_param_array[*adv_id], 0, sizeof(M_MULTI_ADV_PARAM));
+	*adv_id = MAX_ADV_NUMBER;
+
+	return 0;
+}
+
+bool matter_multi_adv_start_by_id(uint8_t *adv_id, uint8_t *adv_data, uint16_t adv_len, uint8_t *rsp_data, uint16_t rsp_len, uint8_t type)
+{
+	if (ble_matter_adapter_peripheral_app_max_links != 0) {
+		printf("[%s] as slave role, BLE is conneted\r\n", __func__);
+		return 1;
+	}
+
+	if ((MAX_ADV_NUMBER != *adv_id) && (matter_multi_adv_param_array[*adv_id].is_used == 1)) {
+		os_timer_stop(&matter_multi_adv_param_array[*adv_id].one_shot_timer);
+	} else {
+	
+		*adv_id = matter_get_unused_adv_index();
+		if(MAX_ADV_NUMBER == *adv_id){
+			printf("[%s] Extend the max adv num %d\r\n", __func__, MAX_ADV_NUMBER);
+			return 1;
+		}
+	}
+
+	uint8_t adv_index = *adv_id;
+	M_MULTI_ADV_PARAM *h_adv_param;
+	h_adv_param = matter_multi_adv_param_array + adv_index;
+	if (!h_adv_param->update_adv_mutex) {
+		os_mutex_create(&h_adv_param->update_adv_mutex);
+	}
+	if (type == 1) { //matter
+		os_mutex_take(h_adv_param->update_adv_mutex, 0xFFFF);
+		memcpy(h_adv_param->adv_data, adv_data, adv_len);
+		h_adv_param->adv_datalen = adv_len;
+		h_adv_param->adv_int_min = matter_adv_int_min;
+		h_adv_param->adv_int_max = matter_adv_int_max;
+		h_adv_param->local_bd_type = GAP_LOCAL_ADDR_LE_RANDOM;
+		h_adv_param->H_adv_intval = matter_adv_interval;
+		h_adv_param->is_used = 1;
+		h_adv_param->type = 1;
+		matter_multi_adapter.matter_sta_sto_flag = false;
+		os_mutex_give(h_adv_param->update_adv_mutex);
+	} else if (type == 2) { //customer
+		os_mutex_take(h_adv_param->update_adv_mutex, 0xFFFF);
+		memcpy(h_adv_param->adv_data, adv_data, adv_len);
+		memcpy(h_adv_param->scanrsp_data, rsp_data, rsp_len);
+		h_adv_param->adv_datalen = adv_len;
+		h_adv_param->scanrsp_datalen = rsp_len;
+		h_adv_param->local_bd_type = GAP_LOCAL_ADDR_LE_PUBLIC;
+		h_adv_param->H_adv_intval = 320;
+		h_adv_param->is_used = 1;
+		h_adv_param->type = 2;
+		matter_multi_adapter.customer_sta_sto_flag = false;
+		os_mutex_give(h_adv_param->update_adv_mutex);
+	}
+
+	if(h_adv_param->one_shot_timer == NULL){
+		if (os_timer_create(&h_adv_param->one_shot_timer, "start adv_timer", adv_index, (int)(h_adv_param->H_adv_intval*0.625), 1, ble_matter_adapter_legacy_start_adv_callback) == false){
+			printf("os_timer_create h_adv_param->one_shot_timer fail!\r\n");
+			return 1;
+		}
+	}
+
+	if (matter_multi_adapter.deinit_flag == true) { // If deinit, return 1
+		printf("[%s]device ble deinit flag is set, return 1\r\n", __func__);
+		return 1;
+	}
+	ble_matter_adapter_send_multi_adv_msg(adv_index);
+	os_timer_start(&h_adv_param->one_shot_timer);
+
+	return 0;
+}
+
+uint8_t ble_matter_adapter_judge_adv_stop(uint8_t adv_id)
+{
+	uint8_t flag = 0;
+
+	if (adv_id == customer_adv_id) {
+		matter_multi_adapter.adv_id = adv_id;
+		if (matter_multi_adapter.customer_sta_sto_flag == true) {
+			flag = 1;
+		}
+	} else if (adv_id == matter_adv_id) {
+		matter_multi_adapter.adv_id = adv_id;
+		if (matter_multi_adapter.matter_sta_sto_flag == true) {
+			flag = 1;
+		}
+	}
+
+	return flag;
+}
+
+void ble_matter_adapter_multi_adv_task_func(void *arg)
+{
+	(void)arg;
+	uint8_t adv_id;
+	uint8_t adv_stop_flag = 0;
+
+	while (true) {
+		if (os_msg_recv(matter_multi_adapter.queue_handle, &adv_id, 0xFFFFFFFF) == true) {
+			if (adv_id == matter_multi_adv_bt_deinit_id) { // If deinit, break the outer while loop
+				printf("[%s]device ble deinit flag is set, break\r\n", __func__);
+				break;
+			} else if (adv_id == customer_adv_id) {
+				//printf("[%s] adv_id = %d  customer_adv_id\r\n", __func__, adv_id);
+				matter_multi_adapter.adv_id = customer_adv_id;
+				if (matter_multi_adapter.customer_sta_sto_flag == true) {
+					printf("[%s]stop customer conn adv flag is set[%d]continue\r\n", __func__, adv_id);
+					continue;
+				}
+			} else if (adv_id == matter_adv_id) {
+				//printf("[%s] adv_id = %d  matter_adv_id\r\n", __func__, adv_id);
+				matter_multi_adapter.adv_id = matter_adv_id;
+				if (matter_multi_adapter.matter_sta_sto_flag == true) {
+					printf("[%s]stop matter conn adv flag is set[%d], continue\r\n", __func__, adv_id);
+					continue;
+				}
+			} else {
+				continue;
+			}
+
+			matter_multi_adv_param_array[adv_id].adv_id = adv_id;
+			if (matter_multi_adv_param_array[adv_id].local_bd_type == GAP_LOCAL_ADDR_LE_PUBLIC) {
+				le_cfg_local_identity_address(matter_local_public_addr, GAP_IDENT_ADDR_PUBLIC);
+			} else if (matter_multi_adv_param_array[adv_id].local_bd_type == GAP_LOCAL_ADDR_LE_RANDOM) {
+				le_cfg_local_identity_address(matter_local_static_random_addr, GAP_IDENT_ADDR_RAND);
+			}
+			le_adv_set_param(GAP_PARAM_ADV_LOCAL_ADDR_TYPE, sizeof(matter_multi_adv_param_array[adv_id].local_bd_type), &matter_multi_adv_param_array[adv_id].local_bd_type);
+			if (matter_multi_adv_param_array[adv_id].update_adv_mutex) {
+				os_mutex_take(matter_multi_adv_param_array[adv_id].update_adv_mutex, 0xFFFF);
+				le_adv_set_param(GAP_PARAM_ADV_DATA, matter_multi_adv_param_array[adv_id].adv_datalen, (void *)matter_multi_adv_param_array[adv_id].adv_data);
+				if (matter_multi_adv_param_array[adv_id].type == 2) { //customer
+					le_adv_set_param(GAP_PARAM_SCAN_RSP_DATA, matter_multi_adv_param_array[adv_id].scanrsp_datalen, (void *)matter_multi_adv_param_array[adv_id].scanrsp_data);
+				} else if (matter_multi_adv_param_array[adv_id].type == 1) { //matter
+					le_adv_set_param(GAP_PARAM_ADV_INTERVAL_MIN, sizeof(matter_multi_adv_param_array[adv_id].adv_int_min), &matter_multi_adv_param_array[adv_id].adv_int_min);
+					le_adv_set_param(GAP_PARAM_ADV_INTERVAL_MAX, sizeof(matter_multi_adv_param_array[adv_id].adv_int_max), &matter_multi_adv_param_array[adv_id].adv_int_max);
+				}
+				os_mutex_give(matter_multi_adv_param_array[adv_id].update_adv_mutex);
+			} else {
+				printf("[%s]update_adv_mutex is NULL[%d]\r\n", __func__, adv_id);
+			}
+			if (ble_matter_adapter_app_send_api_msg(0, &matter_multi_adv_param_array[adv_id]) == false) {
+				printf("[%s]send api msg fail\r\n", __func__);
+				continue;
+			}
+			if (os_sem_take(matter_multi_adapter.sem_handle, 0xFFFFFFFF) == false) {
+				printf("os_sem_take matter_multi_adapter.sem_handle fail!\r\n");
+			}
+		}
+	}
+	printf("delete multi_adv_task\r\n");
+	os_sem_delete(matter_multi_adapter.sem_handle);
+	os_msg_queue_delete(matter_multi_adapter.queue_handle);
+	memset(&matter_multi_adapter, 0, sizeof(matter_multi_adapter));
+	os_task_delete(NULL);
+}
+
+void ble_matter_adapter_multi_adv_init()
+{
+	memset(&matter_multi_adapter, 0, sizeof(matter_multi_adapter));
+	matter_multi_adapter.deinit_flag = false;
+	matter_multi_adapter.matter_sta_sto_flag = true;
+	matter_multi_adapter.customer_sta_sto_flag = true;
+	matter_multi_adapter.adv_id = MAX_ADV_NUMBER;
+	matter_multi_adv_param_array[0].connect_flag = false;
+	matter_multi_adv_param_array[1].connect_flag = false;
+
+	if (os_sem_create(&matter_multi_adapter.sem_handle, 0, 1) == false) {
+		printf("os_sem_create ms_milti_adapter.sem_handle fail!\r\n");
+	}
+	if (os_msg_queue_create(&matter_multi_adapter.queue_handle, MATTER_MULTI_ADV_DATA_QUEUE_SIZE, sizeof(uint8_t)) == false) {
+		printf("os_msg_queue_create ms_milti_adapter.queue_handle fail!\r\n");
+	}
+
+	if (os_task_create(&matter_multi_adapter.task_handle, "multi_adv_task", ble_matter_adapter_multi_adv_task_func, NULL, MATTER_MULTI_TASK_STACK_SIZE, MATTER_MULTI_TASK_PRIORITY) == false) {
+		printf("os_task_create ms_milti_adapter.task_handle fail!\r\n");
+	}
+
+	memset(matter_multi_adv_param_array, 0, sizeof(M_MULTI_ADV_PARAM) * MAX_ADV_NUMBER);
+}
+
+void ble_matter_adapter_multi_adv_deinit()
+{
+	for(int i = 0; i < MAX_ADV_NUMBER; i ++){
+		if(matter_multi_adv_param_array[i].one_shot_timer){
+			os_timer_delete(&matter_multi_adv_param_array[i].one_shot_timer);
+		}
+	}
+	memset(matter_multi_adv_param_array, 0, MAX_ADV_NUMBER * sizeof(M_MULTI_ADV_PARAM));
+	matter_multi_adapter.deinit_flag = true;
+	ble_matter_adapter_send_multi_adv_msg(matter_multi_adv_bt_deinit_id);
+
+	if (matter_multi_adapter.sem_handle) {
+		if (os_sem_give(matter_multi_adapter.sem_handle) == false) {
+			printf("[%s]os_sem_give fail\r\n", __func__);
+		}
+	}
+}
+
+void ble_matter_adapter_send_multi_adv_msg(uint8_t adv_id)
+{
+	if (matter_multi_adapter.deinit_flag == true) {
+		return;
+	}
+	if (matter_multi_adapter.queue_handle != NULL) {
+		if(os_msg_send(matter_multi_adapter.queue_handle, &adv_id, 0) == false){
+		printf("Send adv id to adv data queue fail[%d]\r\n", adv_id);
+		}
+	} else {
+		printf("matter_multi_adapter.queue_handle is NULL\r\n");
+	}
+}
+
+void ble_matter_adapter_legacy_start_adv_callback(void *data)
+{
+	int timerID;
+	os_timer_id_get(&data,&timerID);
+	if (matter_multi_adapter.deinit_flag == true) {
+		return;
+	}
+	ble_matter_adapter_send_multi_adv_msg(timerID);
+}
+
+void ble_matter_adapter_delete_adv(uint8_t adv_id)
+{
+	if(matter_multi_adv_param_array[adv_id].one_shot_timer){
+		os_timer_delete(&matter_multi_adv_param_array[adv_id].one_shot_timer);
+	}
+	if(matter_multi_adv_param_array[adv_id].update_adv_mutex) {
+		os_mutex_delete(matter_multi_adv_param_array[adv_id].update_adv_mutex);
+	}
+	memset(&matter_multi_adv_param_array[adv_id], 0, sizeof(M_MULTI_ADV_PARAM));
+
+}
+#endif
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+int ble_matter_adapter_app_handle_upstream_msg(uint16_t subtype, void *pdata)
+{
+    int ret = 0;
+
+    BT_MATTER_SERVER_SEND_DATA *param = (BT_MATTER_SERVER_SEND_DATA *)pdata;
+    if(param)
+    {
+        server_send_data(param->conn_id, param->service_id, param->attrib_index, param->p_data, param->data_len, param->type);
+        os_mem_free(param->p_data);
+        os_mem_free(param);
+    }
+
+    return ret;
+}
+
+void ble_matter_adapter_app_handle_callback_msg(T_IO_MSG callback_msg)
+{
+    uint16_t msg_type = callback_msg.type;
+    switch (msg_type)
+    {
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	case BLE_MATTER_MSG_CONNECTED_MULTI_ADV: {
+            BT_MATTER_CONN_EVENT *connected = callback_msg.u.buf;
+            T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG gap_connect_cb_arg;
+            gap_connect_cb_arg.conn_id = connected->conn_id;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_GAP_CONNECT_CB, &gap_connect_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+	case BLE_MATTER_MSG_DISCONNECTED_MULTI_ADV: {
+            BT_MATTER_CONN_EVENT *disconnected = callback_msg.u.buf;
+            T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG gap_disconnect_cb_arg;
+            gap_disconnect_cb_arg.conn_id = disconnected->conn_id;
+            gap_disconnect_cb_arg.disc_cause = disconnected->disc_cause;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_GAP_DISCONNECT_CB, &gap_disconnect_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+	case BLE_MATTER_MSG_WRITE_CHAR_MULTI_ADV: {
+            T_MATTER_CALLBACK_DATA *write_char_val = callback_msg.u.buf;
+            T_MATTER_BLEMGR_RX_CHAR_WRITE_CB_ARG rx_char_write_cb_arg;
+            rx_char_write_cb_arg.conn_id = write_char_val->conn_id;
+            rx_char_write_cb_arg.p_value = write_char_val->msg_data.write_read.p_value;
+            rx_char_write_cb_arg.len = write_char_val->msg_data.write_read.len;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_RX_CHAR_WRITE_CB, &rx_char_write_cb_arg);
+            }
+            if (write_char_val->msg_data.write_read.len != 0)
+            {
+                os_mem_free(write_char_val->msg_data.write_read.p_value);
+                write_char_val->msg_data.write_read.p_value = NULL;
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+    case BLE_MATTER_MSG_CCCD_RECV_ENABLE_MULTI_ADV: {
+               matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_TX_CHAR_CCCD_WRITE_CB, callback_msg.u.buf);
+               os_mem_free(callback_msg.u.buf);
+        }
+        break;
+    case BLE_MATTER_MSG_CCCD_RECV_DISABLE_MULTI_ADV:
+    case BLE_MATTER_MSG_SEND_DATA_COMPLETE_MULTI_ADV: {
+               matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_TX_COMPLETE_CB, callback_msg.u.buf);
+               os_mem_free(callback_msg.u.buf);
+        }
+        break;
+#else
+    case BT_MATTER_SEND_CB_MSG_CONNECTED:
+        {
+            BT_MATTER_CONN_EVENT *connected = callback_msg.u.buf;
+            T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG gap_connect_cb_arg;
+            gap_connect_cb_arg.conn_id = connected->conn_id;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_GAP_CONNECT_CB, &gap_connect_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+    case BT_MATTER_SEND_CB_MSG_DISCONNECTED:
+        {
+            BT_MATTER_CONN_EVENT *disconnected = callback_msg.u.buf;
+            T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG gap_disconnect_cb_arg;
+            gap_disconnect_cb_arg.conn_id = disconnected->conn_id;
+            gap_disconnect_cb_arg.disc_cause = disconnected->disc_cause;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_GAP_DISCONNECT_CB, &gap_disconnect_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+    case BT_MATTER_SEND_CB_MSG_WRITE_CHAR:
+        {
+            T_MATTER_CALLBACK_DATA *write_char_val = callback_msg.u.buf;
+            T_MATTER_BLEMGR_RX_CHAR_WRITE_CB_ARG rx_char_write_cb_arg;
+            rx_char_write_cb_arg.conn_id = write_char_val->conn_id;
+            rx_char_write_cb_arg.p_value = write_char_val->msg_data.write_read.p_value;
+            rx_char_write_cb_arg.len = write_char_val->msg_data.write_read.len;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_RX_CHAR_WRITE_CB, &rx_char_write_cb_arg);
+            }
+            if (write_char_val->msg_data.write_read.len != 0)
+            {
+                os_mem_free(write_char_val->msg_data.write_read.p_value);
+                write_char_val->msg_data.write_read.p_value = NULL;
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+    case BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE:
+    case BT_MATTER_SEND_CB_MSG_IND_NTF_DISABLE:
+        {
+            T_MATTER_CALLBACK_DATA *indication_notification_enable = callback_msg.u.buf;
+            T_MATTER_BLEMGR_TX_CHAR_CCCD_WRITE_CB_ARG tx_char_cccd_write_cb_arg;
+            tx_char_cccd_write_cb_arg.conn_id = indication_notification_enable->conn_id;
+            if (msg_type == BT_MATTER_SEND_CB_MSG_IND_NTF_DISABLE)
+                tx_char_cccd_write_cb_arg.indicationsEnabled = 0;
+            else if (msg_type == BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE)
+                tx_char_cccd_write_cb_arg.indicationsEnabled = 1;
+            tx_char_cccd_write_cb_arg.notificationsEnabled = 0;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_TX_CHAR_CCCD_WRITE_CB, &tx_char_cccd_write_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+    case BT_MATTER_SEND_CB_MSG_SEND_DATA_COMPLETE:
+        {
+            T_SERVER_APP_CB_DATA *send_data_complete = callback_msg.u.buf;
+            T_MATTER_BLEMGR_TX_COMPLETE_CB_ARG tx_complete_cb_arg;
+            tx_complete_cb_arg.conn_id = send_data_complete->event_data.send_data_result.conn_id;
+            if (matter_blemgr_callback_func) {
+                matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_TX_COMPLETE_CB, &tx_complete_cb_arg);
+            }
+            os_mem_free(callback_msg.u.buf);
+            callback_msg.u.buf = NULL;
+        }
+        break;
+
+#endif
+	default:
+		printf("[%s] unknow type(%d) callback msg\r\n", __func__, callback_msg.type);
+		break;
+	}
+}
+
+void ble_matter_adapter_app_handle_io_msg(T_IO_MSG io_msg)
+{
+    uint16_t msg_type = io_msg.type;
+    switch (msg_type)
+    {
+    case IO_MSG_TYPE_BT_STATUS:
+        {
+            ble_matter_adapter_app_handle_gap_msg(&io_msg);
+        }
+        break;
+    case IO_MSG_TYPE_UART:
+        {
+            /* We handle user command informations from Data UART in this branch. */
+            //int8_t data = io_msg.subtype;
+            //mesh_user_cmd_collect(&data, sizeof(data), device_cmd_table);
+        }
+        break;
+    case IO_MSG_TYPE_AT_CMD:
+        {
+            //uint16_t subtype = io_msg.subtype;
+            //void *arg = io_msg.u.buf;
+            //if (ble_central_app_handle_at_cmd(subtype, arg) != 1) {
+                //ble_peripheral_app_handle_at_cmd(subtype, arg);
+            //}
+        }
+        break;
+    case IO_MSG_TYPE_QDECODE:
+        {
+            if (io_msg.subtype == 0) {
+#if CONFIG_BLE_MATTER_MULTI_ADV
+			M_MULTI_ADV_PARAM *adv_param = io_msg.u.buf;
+			uint8_t adv_stop_flag = 0;
+			adv_stop_flag = ble_matter_adapter_judge_adv_stop(adv_param->adv_id);
+			if (adv_stop_flag) {
+				printf("stop adv flag[%d] is set, give sem and break\r\n", adv_param->adv_id);
+				if(matter_multi_adapter.sem_handle)
+					os_sem_give(matter_multi_adapter.sem_handle);
+				break;
+			}
+			uint8_t cause = le_adv_update_param();
+			if (cause != GAP_CAUSE_SUCCESS) {
+				printf("le_adv_update_param fail! ret = 0x%x\r\n", cause);
+			}
+#endif
+            } else if(io_msg.subtype == 2) {
+                //gap_sched_scan(false);
+            } else if (io_msg.subtype == 3) {
+                //gap_sched_scan(true);
+            } else if (io_msg.subtype == 4) {
+                ble_matter_adapter_app_handle_upstream_msg(io_msg.subtype, io_msg.u.buf);
+            } else if (io_msg.subtype == 5) {
+                uint8_t conn_id = io_msg.u.buf;
+                le_disconnect(conn_id);
+            }
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/**
+ * @brief    Handle msg GAP_MSG_LE_DEV_STATE_CHANGE
+ * @note     All the gap device state events are pre-handled in this function.
+ *           Then the event handling function shall be called according to the new_state
+ * @param[in] new_state  New gap device state
+ * @param[in] cause GAP device state change cause
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_dev_state_evt(T_GAP_DEV_STATE new_state, uint16_t cause)
+{
+	APP_PRINT_INFO3("ble_matter_adapter_dev_state_evt: init state  %d, scan state %d, cause 0x%x",
+					new_state.gap_init_state,
+					new_state.gap_scan_state, cause);
+	if (ble_matter_adapter_gap_dev_state.gap_init_state != new_state.gap_init_state) {
+		if (new_state.gap_init_state == GAP_INIT_STATE_STACK_READY) {
+			uint8_t bt_addr[6];
+			APP_PRINT_INFO0("GAP stack ready");
+			/*stack ready*/
+			gap_get_param(GAP_PARAM_BD_ADDR, bt_addr);
+			printf("local bd addr: %02x:%02x:%02x:%02x:%02x:%02x\r\n",
+				   bt_addr[5],
+				   bt_addr[4],
+				   bt_addr[3],
+				   bt_addr[2],
+				   bt_addr[1],
+				   bt_addr[0]);
+#if CONFIG_BLE_MATTER_MULTI_ADV
+			memcpy(matter_local_public_addr, bt_addr, 6);
+#endif
+		}
+	}
+
+	if (ble_matter_adapter_gap_dev_state.gap_scan_state != new_state.gap_scan_state) {
+		if (new_state.gap_scan_state == GAP_SCAN_STATE_IDLE) {
+			APP_PRINT_INFO0("GAP scan stop");
+			printf("GAP scan stop\r\n");
+			
+		} else if (new_state.gap_scan_state == GAP_SCAN_STATE_SCANNING) {
+			APP_PRINT_INFO0("GAP scan start");
+			printf("GAP scan start\r\n");
+		}
+	}
+
+	if (ble_matter_adapter_gap_dev_state.gap_adv_state != new_state.gap_adv_state) {
+		if (new_state.gap_adv_state == GAP_ADV_STATE_IDLE) {
+			if (new_state.gap_adv_sub_state == GAP_ADV_TO_IDLE_CAUSE_CONN) {
+				APP_PRINT_INFO0("GAP adv stoped: because connection created");
+				printf("GAP adv stoped: because connection created\r\n");
+			} else {
+				APP_PRINT_INFO0("GAP adv stoped");
+				printf("GAP adv stopped\r\n");
+			}
+			
+		} else if (new_state.gap_adv_state == GAP_ADV_STATE_ADVERTISING) {
+			APP_PRINT_INFO0("GAP adv start");
+			printf("GAP adv start\r\n");
+		}
+	}
+	ble_matter_adapter_gap_dev_state = new_state;
+}
+
+/**
+ * @brief    Handle msg GAP_MSG_LE_CONN_STATE_CHANGE
+ * @note     All the gap conn state events are pre-handled in this function.
+ *           Then the event handling function shall be called according to the new_state
+ * @param[in] conn_id Connection ID
+ * @param[in] new_state  New gap connection state
+ * @param[in] disc_cause Use this cause when new_state is GAP_CONN_STATE_DISCONNECTED
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_conn_state_evt(uint8_t conn_id, T_GAP_CONN_STATE new_state, uint16_t disc_cause)
+{
+	T_GAP_CONN_INFO conn_info;
+	if (conn_id >= BLE_MATTER_ADAPTER_APP_MAX_LINKS) {
+		return;
+	}
+
+	APP_PRINT_INFO4("ble_matter_adapter_app_handle_conn_state_evt: conn_id %d, conn_state(%d -> %d), disc_cause 0x%x",
+					conn_id, ble_matter_adapter_app_link_table[conn_id].conn_state, new_state, disc_cause);
+	ble_matter_adapter_app_link_table[conn_id].conn_state = new_state;
+	switch (new_state) {
+	case GAP_CONN_STATE_DISCONNECTED: {
+		if ((disc_cause != (HCI_ERR | HCI_ERR_REMOTE_USER_TERMINATE))
+			&& (disc_cause != (HCI_ERR | HCI_ERR_LOCAL_HOST_TERMINATE))) {
+			APP_PRINT_ERROR2("ble_matter_adapter_app_handle_conn_state_evt: connection lost, conn_id %d, cause 0x%x", conn_id,
+							 disc_cause);
+		}
+		printf("Disconnect conn_id %d, cause 0x%x\r\n", conn_id, disc_cause);
+
+		if (ble_matter_adapter_app_link_table[conn_id].role == GAP_LINK_ROLE_MASTER) {
+			ble_matter_adapter_central_app_max_links --;
+		} else if (ble_matter_adapter_app_link_table[conn_id].role == GAP_LINK_ROLE_SLAVE) {
+			ble_matter_adapter_peripheral_app_max_links --;
+		}
+
+		if (ble_matter_adapter_app_link_table[conn_id].role == GAP_LINK_ROLE_SLAVE) {
+			printf("As peripheral,recieve disconncect,please start ADV\r\n");
+		}
+
+		memset(&ble_matter_adapter_app_link_table[conn_id], 0, sizeof(T_APP_LINK));
+#if CONFIG_BLE_MATTER_MULTI_ADV
+		if (link_customer == 1) { //matter
+        //if(matter_multi_adv_param_array[0].connect_flag == true) {
+			matter_multi_adv_param_array[0].connect_flag = false;
+
+			if(!matter_server_is_commissioned()) {
+				matter_multi_adv_start_by_id(&matter_adv_id, matter_adv_data, matter_adv_data_length, NULL, 0, 1); // the last parameter: 1 for Matter; 2 for Customer
+			}
+#if 1  //send data to matter
+			T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG *disconnected_msg_matter = (T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG *)os_mem_alloc(0, sizeof(T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG));
+			memset(disconnected_msg_matter, 0, sizeof(T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG));
+			disconnected_msg_matter->conn_id = conn_id;
+			disconnected_msg_matter->disc_cause = disc_cause;
+			if (ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_DISCONNECTED_MULTI_ADV,NULL, disconnected_msg_matter) == false) {
+				printf("[%s] send callback msg fail\r\n", __func__);
+				os_mem_free(disconnected_msg_matter);
+			}
+#endif
+		//}
+		} else if (link_customer == 2) { //customer
+		//if(matter_multi_adv_param_array[1].connect_flag == true) {
+				matter_multi_adv_param_array[1].connect_flag = false;
+				matter_multi_adv_start_by_id(&customer_adv_id, customer_adv_data, customer_adv_data_length, customer_rsp_data, customer_rsp_data_length, 2);
+		//}
+		}
+#else
+        //send data to matter
+        BT_MATTER_CONN_EVENT *disconnected = os_mem_alloc(0, sizeof(BT_MATTER_CONN_EVENT));
+	    if(disconnected)
+	    {
+	        disconnected->conn_id = conn_id;
+	        disconnected->new_state = new_state;
+	        disconnected->disc_cause = disc_cause;
+	        if(ble_matter_adapter_send_callback_msg(BT_MATTER_SEND_CB_MSG_DISCONNECTED, NULL, disconnected)==false)
+	        {
+	            os_mem_free(disconnected);
+	        }
+	    }
+	    else
+	        printf("Malloc failed\r\n");
+#endif
+
+	}
+	break;
+
+	case GAP_CONN_STATE_CONNECTED: {
+	    uint16_t conn_interval;
+        uint16_t conn_latency;
+        uint16_t conn_supervision_timeout;
+        
+		le_get_conn_addr(conn_id, ble_matter_adapter_app_link_table[conn_id].bd_addr,
+						 (void *)&ble_matter_adapter_app_link_table[conn_id].bd_type);
+
+		//get device role
+		if (le_get_conn_info(conn_id, &conn_info)) {
+		ble_matter_adapter_app_link_table[conn_id].role = conn_info.role;
+		if (ble_matter_adapter_app_link_table[conn_id].role == GAP_LINK_ROLE_MASTER) {
+			ble_matter_adapter_central_app_max_links ++;
+		} else if (ble_matter_adapter_app_link_table[conn_id].role == GAP_LINK_ROLE_SLAVE) {
+			ble_matter_adapter_peripheral_app_max_links ++;			}
+		}
+		printf("Connected success conn_id %d\r\n", conn_id);
+		
+        uint8_t local_bd_type;
+        uint8_t remote_bd_type;
+		le_get_conn_param(GAP_PARAM_CONN_LOCAL_BD_TYPE, &local_bd_type, conn_id);
+		le_get_conn_param(GAP_PARAM_CONN_BD_ADDR_TYPE, &remote_bd_type, conn_id);
+		APP_PRINT_INFO3("GAP_CONN_STATE_CONNECTED: conn_id %d, local_bd_type %d, remote_bd_type %d\n",
+						conn_id, local_bd_type, remote_bd_type);
+		printf("GAP_CONN_STATE_CONNECTED: conn_id %d, local_bd_type %d, remote_bd_type %d\n",
+			   conn_id, local_bd_type, remote_bd_type);
+			   
+        le_get_conn_param(GAP_PARAM_CONN_INTERVAL, &conn_interval, conn_id);
+        le_get_conn_param(GAP_PARAM_CONN_LATENCY, &conn_latency, conn_id);
+        le_get_conn_param(GAP_PARAM_CONN_TIMEOUT, &conn_supervision_timeout, conn_id);            
+		le_get_conn_addr(conn_id, ble_matter_adapter_app_link_table[conn_id].bd_addr,
+                             &ble_matter_adapter_app_link_table[conn_id].bd_type);
+        APP_PRINT_INFO5("GAP_CONN_STATE_CONNECTED:remote_bd %s, remote_addr_type %d, conn_interval 0x%x, conn_latency 0x%x, conn_supervision_timeout 0x%x",
+                            TRACE_BDADDR(ble_matter_adapter_app_link_table[conn_id].bd_addr), ble_matter_adapter_app_link_table[conn_id].bd_type,
+                            conn_interval, conn_latency, conn_supervision_timeout);
+        printf("Connected success conn_id %d\r\n", conn_id);
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+		//get local adv bt type
+		if (local_bd_type == GAP_LOCAL_ADDR_LE_RANDOM) { // matter
+			link_customer = 1;
+			T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG *conn_msg_matter = (T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG *)os_mem_alloc(0, sizeof(T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG));
+			memset(conn_msg_matter, 0, sizeof(T_MATTER_BLEMGR_GAP_CONNECT_CB_ARG));
+			conn_msg_matter->conn_id = conn_id;
+			if (ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_CONNECTED_MULTI_ADV, NULL, conn_msg_matter) == false) {
+				printf("[%s] send callback msg fail\r\n", __func__);
+				os_mem_free(conn_msg_matter);
+			}
+                matter_multi_adv_param_array[0].connect_flag == true;
+                matter_multi_adv_stop_by_id(&matter_adv_id); // stop matter adv
+		} else if (local_bd_type == GAP_LOCAL_ADDR_LE_PUBLIC) { // customer
+                link_customer = 2;
+                matter_multi_adv_param_array[1].connect_flag == true;
+		matter_multi_adv_stop_by_id(&customer_adv_id); // stop customer adv
+		}
+#else	   
+	    //send data to matter
+        BT_MATTER_CONN_EVENT *connected = os_mem_alloc(0, sizeof(BT_MATTER_CONN_EVENT));
+        if(connected)
+        {
+        	connected->conn_id = conn_id;
+            connected->new_state = new_state;
+            connected->disc_cause = disc_cause;
+            if(ble_matter_adapter_send_callback_msg(BT_MATTER_SEND_CB_MSG_CONNECTED, NULL, connected)==false)
+            {
+                os_mem_free(connected);
+            }
+        }
+        else
+            printf("Malloc failed\r\n");
+#endif
+
+#if F_BT_LE_5_0_SET_PHY_SUPPORT
+		{
+			uint8_t tx_phy;
+			uint8_t rx_phy;
+			le_get_conn_param(GAP_PARAM_CONN_RX_PHY_TYPE, &rx_phy, conn_id);
+			le_get_conn_param(GAP_PARAM_CONN_TX_PHY_TYPE, &tx_phy, conn_id);
+			APP_PRINT_INFO2("GAP_CONN_STATE_CONNECTED: tx_phy %d, rx_phy %d\n", tx_phy, rx_phy);
+			printf("GAP_CONN_STATE_CONNECTED: tx_phy %d, rx_phy %d\n", tx_phy, rx_phy);
+		}
+#endif	   
+	}
+	break;
+
+	default:
+		break;
+
+	}
+}
+
+/**
+ * @brief    Handle msg GAP_MSG_LE_AUTHEN_STATE_CHANGE
+ * @note     All the gap authentication state events are pre-handled in this function.
+ *           Then the event handling function shall be called according to the new_state
+ * @param[in] conn_id Connection ID
+ * @param[in] new_state  New authentication state
+ * @param[in] cause Use this cause when new_state is GAP_AUTHEN_STATE_COMPLETE
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_authen_state_evt(uint8_t conn_id, uint8_t new_state, uint16_t cause)
+{
+	APP_PRINT_INFO2("ble_matter_adapter_app_handle_authen_state_evt:conn_id %d, cause 0x%x", conn_id, cause);
+	switch (new_state) {
+	case GAP_AUTHEN_STATE_STARTED: {
+		APP_PRINT_INFO0("ble_matter_adapter_app_handle_authen_state_evt: GAP_AUTHEN_STATE_STARTED");
+	}
+	break;
+
+	case GAP_AUTHEN_STATE_COMPLETE: {
+		if (cause == GAP_SUCCESS) {
+			printf("Pair success\r\n");
+			APP_PRINT_INFO0("ble_matter_adapter_app_handle_authen_state_evt: GAP_AUTHEN_STATE_COMPLETE pair success");
+		} else {
+			printf("Pair failed: cause 0x%x\r\n", cause);
+			APP_PRINT_INFO0("ble_matter_adapter_app_handle_authen_state_evt: GAP_AUTHEN_STATE_COMPLETE pair failed");
+		}
+	}
+	break;
+
+	default: {
+		APP_PRINT_ERROR1("ble_matter_adapter_app_handle_authen_state_evt: unknown newstate %d", new_state);
+	}
+	break;
+	}
+}
+
+/**
+ * @brief    Handle msg GAP_MSG_LE_CONN_MTU_INFO
+ * @note     This msg is used to inform APP that exchange mtu procedure is completed.
+ * @param[in] conn_id Connection ID
+ * @param[in] mtu_size  New mtu size
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_conn_mtu_info_evt(uint8_t conn_id, uint16_t mtu_size)
+{
+	APP_PRINT_INFO2("ble_matter_adapter_app_handle_conn_mtu_info_evt: conn_id %d, mtu_size %d", conn_id, mtu_size);
+}
+
+/**
+ * @brief    Handle msg GAP_MSG_LE_CONN_PARAM_UPDATE
+ * @note     All the connection parameter update change  events are pre-handled in this function.
+ * @param[in] conn_id Connection ID
+ * @param[in] status  New update state
+ * @param[in] cause Use this cause when status is GAP_CONN_PARAM_UPDATE_STATUS_FAIL
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_conn_param_update_evt(uint8_t conn_id, uint8_t status, uint16_t cause)
+{
+	switch (status) {
+	case GAP_CONN_PARAM_UPDATE_STATUS_SUCCESS: {
+		uint16_t conn_interval;
+		uint16_t conn_slave_latency;
+		uint16_t conn_supervision_timeout;
+
+		le_get_conn_param(GAP_PARAM_CONN_INTERVAL, &conn_interval, conn_id);
+		le_get_conn_param(GAP_PARAM_CONN_LATENCY, &conn_slave_latency, conn_id);
+		le_get_conn_param(GAP_PARAM_CONN_TIMEOUT, &conn_supervision_timeout, conn_id);
+		APP_PRINT_INFO4("ble_matter_adapter_app_handle_conn_param_update_evt update success:conn_id %d, conn_interval 0x%x, conn_slave_latency 0x%x, conn_supervision_timeout 0x%x",
+						conn_id, conn_interval, conn_slave_latency, conn_supervision_timeout);
+	}
+	break;
+
+	case GAP_CONN_PARAM_UPDATE_STATUS_FAIL: {
+		APP_PRINT_ERROR2("ble_matter_adapter_app_handle_conn_param_update_evt update failed: conn_id %d, cause 0x%x",
+						 conn_id, cause);
+	}
+	break;
+
+	case GAP_CONN_PARAM_UPDATE_STATUS_PENDING: {
+		APP_PRINT_INFO1("ble_matter_adapter_app_handle_conn_param_update_evt update pending: conn_id %d", conn_id);
+	}
+	break;
+
+	default:
+		break;
+	}
+}
+
+/**
+ * @brief    All the BT GAP MSG are pre-handled in this function.
+ * @note     Then the event handling function shall be called according to the
+ *           subtype of T_IO_MSG
+ * @param[in] p_gap_msg Pointer to GAP msg
+ * @return   void
+ */
+void ble_matter_adapter_app_handle_gap_msg(T_IO_MSG *p_gap_msg)
+{
+	T_LE_GAP_MSG gap_msg;
+	uint8_t conn_id;
+	memcpy(&gap_msg, &p_gap_msg->u.param, sizeof(p_gap_msg->u.param));
+
+	APP_PRINT_TRACE1("ble_matter_adapter_app_handle_gap_msg: subtype %d", p_gap_msg->subtype);
+	switch (p_gap_msg->subtype) {
+	case GAP_MSG_LE_DEV_STATE_CHANGE: {
+		ble_matter_adapter_app_handle_dev_state_evt(gap_msg.msg_data.gap_dev_state_change.new_state,
+												gap_msg.msg_data.gap_dev_state_change.cause);
+	}
+	break;
+
+	case GAP_MSG_LE_CONN_STATE_CHANGE: {
+		ble_matter_adapter_app_handle_conn_state_evt(gap_msg.msg_data.gap_conn_state_change.conn_id,
+				(T_GAP_CONN_STATE)gap_msg.msg_data.gap_conn_state_change.new_state,
+				gap_msg.msg_data.gap_conn_state_change.disc_cause);
+	}
+	break;
+
+	case GAP_MSG_LE_CONN_MTU_INFO: {
+		ble_matter_adapter_app_handle_conn_mtu_info_evt(gap_msg.msg_data.gap_conn_mtu_info.conn_id,
+				gap_msg.msg_data.gap_conn_mtu_info.mtu_size);
+	}
+	break;
+
+	case GAP_MSG_LE_CONN_PARAM_UPDATE: {
+		ble_matter_adapter_app_handle_conn_param_update_evt(gap_msg.msg_data.gap_conn_param_update.conn_id,
+				gap_msg.msg_data.gap_conn_param_update.status,
+				gap_msg.msg_data.gap_conn_param_update.cause);
+	}
+	break;
+
+	case GAP_MSG_LE_AUTHEN_STATE_CHANGE: {
+		ble_matter_adapter_app_handle_authen_state_evt(gap_msg.msg_data.gap_authen_state.conn_id,
+				gap_msg.msg_data.gap_authen_state.new_state,
+				gap_msg.msg_data.gap_authen_state.status);
+	}
+	break;
+
+	case GAP_MSG_LE_BOND_JUST_WORK: {
+		conn_id = gap_msg.msg_data.gap_bond_just_work_conf.conn_id;
+		le_bond_just_work_confirm(conn_id, GAP_CFM_CAUSE_ACCEPT);
+		APP_PRINT_INFO0("GAP_MSG_LE_BOND_JUST_WORK");
+	}
+	break;
+
+	case GAP_MSG_LE_BOND_PASSKEY_DISPLAY: {
+		uint32_t display_value = 0;
+		conn_id = gap_msg.msg_data.gap_bond_passkey_display.conn_id;
+		le_bond_get_display_key(conn_id, &display_value);
+		APP_PRINT_INFO2("GAP_MSG_LE_BOND_PASSKEY_DISPLAY: conn_id %d, passkey %d",
+						conn_id, display_value);
+		le_bond_passkey_display_confirm(conn_id, GAP_CFM_CAUSE_ACCEPT);
+		printf("GAP_MSG_LE_BOND_PASSKEY_DISPLAY: conn_id %d, passkey %d\r\n",
+			   conn_id,
+			   display_value);
+	}
+	break;
+
+	case GAP_MSG_LE_BOND_USER_CONFIRMATION: {
+		uint32_t display_value = 0;
+		conn_id = gap_msg.msg_data.gap_bond_user_conf.conn_id;
+		le_bond_get_display_key(conn_id, &display_value);
+		APP_PRINT_INFO2("GAP_MSG_LE_BOND_USER_CONFIRMATION: conn_id %d, passkey %d",
+						conn_id, display_value);
+		printf("GAP_MSG_LE_BOND_USER_CONFIRMATION: conn_id %d, passkey %d\r\n",
+			   conn_id,
+			   display_value);
+		//le_bond_user_confirm(conn_id, GAP_CFM_CAUSE_ACCEPT);
+	}
+	break;
+
+	case GAP_MSG_LE_BOND_PASSKEY_INPUT: {
+		//uint32_t passkey = 888888;
+		conn_id = gap_msg.msg_data.gap_bond_passkey_input.conn_id;
+		APP_PRINT_INFO1("GAP_MSG_LE_BOND_PASSKEY_INPUT: conn_id %d", conn_id);
+		printf("GAP_MSG_LE_BOND_PASSKEY_INPUT: conn_id %d\r\n", conn_id);
+		//le_bond_passkey_input_confirm(conn_id, passkey, GAP_CFM_CAUSE_ACCEPT);
+	}
+	break;
+#if F_BT_LE_SMP_OOB_SUPPORT
+	case GAP_MSG_LE_BOND_OOB_INPUT: {
+		uint8_t oob_data[GAP_OOB_LEN] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+		conn_id = gap_msg.msg_data.gap_bond_oob_input.conn_id;
+		APP_PRINT_INFO1("GAP_MSG_LE_BOND_OOB_INPUT: conn_id %d", conn_id);
+		le_bond_set_param(GAP_PARAM_BOND_OOB_DATA, GAP_OOB_LEN, oob_data);
+		le_bond_oob_input_confirm(conn_id, GAP_CFM_CAUSE_ACCEPT);
+	}
+	break;
+#endif
+	default:
+		APP_PRINT_ERROR1("ble_matter_adapter_app_handle_gap_msg: unknown subtype %d", p_gap_msg->subtype);
+		break;
+	}
+}
+
+/** @defgroup  CENTRAL_CLIENT_GAP_CALLBACK GAP Callback Event Handler
+    * @brief Handle GAP callback event
+    * @{
+    */
+/**
+  * @brief Used to parse advertising data and scan response data
+  * @param[in] scan_info point to scan information data.
+  * @retval void
+  */
+void bt_matter_device_matter_app_parse_scan_info(T_LE_SCAN_INFO *scan_info)
+{
+    uint8_t buffer[32];
+    uint8_t pos = 0;
+
+    while (pos < scan_info->data_len)
+    {
+        /* Length of the AD structure. */
+        uint8_t length = scan_info->data[pos++];
+        uint8_t type;
+
+        if ((length > 0x01) && ((pos + length) <= 31))
+        {
+            /* Copy the AD Data to buffer. */
+            memcpy(buffer, scan_info->data + pos + 1, length - 1);
+            /* AD Type, one octet. */
+            type = scan_info->data[pos];
+
+            APP_PRINT_TRACE2("bt_mesh_device_matter_app_parse_scan_info: AD Structure Info: AD type 0x%x, AD Data Length %d", type,
+                             length - 1);
+
+            switch (type)
+            {
+            case GAP_ADTYPE_FLAGS:
+                {
+                    /* (flags & 0x01) -- LE Limited Discoverable Mode */
+                    /* (flags & 0x02) -- LE General Discoverable Mode */
+                    /* (flags & 0x04) -- BR/EDR Not Supported */
+                    /* (flags & 0x08) -- Simultaneous LE and BR/EDR to Same Device Capable (Controller) */
+                    /* (flags & 0x10) -- Simultaneous LE and BR/EDR to Same Device Capable (Host) */
+                    uint8_t flags = scan_info->data[pos + 1];
+                    APP_PRINT_INFO1("GAP_ADTYPE_FLAGS: 0x%x", flags);
+                    BLE_PRINT("GAP_ADTYPE_FLAGS: 0x%x\n\r", flags);
+
+                }
+                break;
+
+            case GAP_ADTYPE_16BIT_MORE:
+            case GAP_ADTYPE_16BIT_COMPLETE:
+            case GAP_ADTYPE_SERVICES_LIST_16BIT:
+                {
+                    uint16_t *p_uuid = (uint16_t *)(buffer);
+                    uint8_t i = length - 1;
+
+                    while (i >= 2)
+                    {
+                        APP_PRINT_INFO1("GAP_ADTYPE_16BIT_XXX: 0x%x", *p_uuid);
+                        BLE_PRINT("GAP_ADTYPE_16BIT_XXX: 0x%x\n\r", *p_uuid);
+                        p_uuid ++;
+                        i -= 2;
+                    }
+                }
+                break;
+
+            case GAP_ADTYPE_32BIT_MORE:
+            case GAP_ADTYPE_32BIT_COMPLETE:
+                {
+                    uint32_t *p_uuid = (uint32_t *)(buffer);
+                    uint8_t    i     = length - 1;
+
+                    while (i >= 4)
+                    {
+                        APP_PRINT_INFO1("GAP_ADTYPE_32BIT_XXX: 0x%x", *p_uuid);
+                        BLE_PRINT("GAP_ADTYPE_32BIT_XXX: 0x%x\n\r", (unsigned int)*p_uuid);
+                        p_uuid ++;
+
+                        i -= 4;
+                    }
+                }
+                break;
+
+            case GAP_ADTYPE_128BIT_MORE:
+            case GAP_ADTYPE_128BIT_COMPLETE:
+            case GAP_ADTYPE_SERVICES_LIST_128BIT:
+                {
+                    uint32_t *p_uuid = (uint32_t *)(buffer);
+                    APP_PRINT_INFO4("GAP_ADTYPE_128BIT_XXX: 0x%8.8x%8.8x%8.8x%8.8x",
+                                    p_uuid[3], p_uuid[2], p_uuid[1], p_uuid[0]);
+                    BLE_PRINT("GAP_ADTYPE_128BIT_XXX: 0x%8.8x%8.8x%8.8x%8.8x\n\r",
+                                    (unsigned int)p_uuid[3], (unsigned int)p_uuid[2], (unsigned int)p_uuid[1], (unsigned int)p_uuid[0]);
+
+                }
+                break;
+
+            case GAP_ADTYPE_LOCAL_NAME_SHORT:
+            case GAP_ADTYPE_LOCAL_NAME_COMPLETE:
+                {
+                    buffer[length - 1] = '\0';
+                    APP_PRINT_INFO1("GAP_ADTYPE_LOCAL_NAME_XXX: %s", TRACE_STRING(buffer));
+                    BLE_PRINT("GAP_ADTYPE_LOCAL_NAME_XXX: %s\n\r", buffer);
+
+                }
+                break;
+
+            case GAP_ADTYPE_POWER_LEVEL:
+                {
+                    APP_PRINT_INFO1("GAP_ADTYPE_POWER_LEVEL: 0x%x", scan_info->data[pos + 1]);
+                    BLE_PRINT("GAP_ADTYPE_POWER_LEVEL: 0x%x\n\r", scan_info->data[pos + 1]);
+
+                }
+                break;
+
+            case GAP_ADTYPE_SLAVE_CONN_INTERVAL_RANGE:
+                {
+                    uint16_t *p_min = (uint16_t *)(buffer);
+                    uint16_t *p_max = p_min + 1;
+                    APP_PRINT_INFO2("GAP_ADTYPE_SLAVE_CONN_INTERVAL_RANGE: 0x%x - 0x%x", *p_min,
+                                    *p_max);
+                    BLE_PRINT("GAP_ADTYPE_SLAVE_CONN_INTERVAL_RANGE: 0x%x - 0x%x\n\r", *p_min, *p_max);
+
+                }
+                break;
+
+            case GAP_ADTYPE_SERVICE_DATA:
+                {
+                    uint16_t *p_uuid = (uint16_t *)(buffer);
+                    uint8_t data_len = length - 3;
+
+                    APP_PRINT_INFO3("GAP_ADTYPE_SERVICE_DATA: UUID 0x%x, len %d, data %b", *p_uuid,
+                                    data_len, TRACE_BINARY(data_len, &buffer[2]));
+                    BLE_PRINT("GAP_ADTYPE_SERVICE_DATA: UUID 0x%x, len %d\n\r", *p_uuid, data_len);
+
+                }
+                break;
+            case GAP_ADTYPE_APPEARANCE:
+                {
+                    uint16_t *p_appearance = (uint16_t *)(buffer);
+                    APP_PRINT_INFO1("GAP_ADTYPE_APPEARANCE: %d", *p_appearance);
+                    BLE_PRINT("GAP_ADTYPE_APPEARANCE: %d\n\r", *p_appearance);
+
+                }
+                break;
+
+            case GAP_ADTYPE_MANUFACTURER_SPECIFIC:
+                {
+                    uint8_t data_len = length - 3;
+                    uint16_t *p_company_id = (uint16_t *)(buffer);
+                    APP_PRINT_INFO3("GAP_ADTYPE_MANUFACTURER_SPECIFIC: company_id 0x%x, len %d, data %b",
+                                    *p_company_id, data_len, TRACE_BINARY(data_len, &buffer[2]));
+                    BLE_PRINT("GAP_ADTYPE_MANUFACTURER_SPECIFIC: company_id 0x%x, len %d\n\r", *p_company_id, data_len);
+
+                }
+                break;
+
+            default:
+                {
+                    uint8_t i = 0;
+
+                    for (i = 0; i < (length - 1); i++)
+                    {
+                        APP_PRINT_INFO1("  AD Data: Unhandled Data = 0x%x", scan_info->data[pos + i]);
+                    //BLE_PRINT("  AD Data: Unhandled Data = 0x%x\n\r", scan_info->data[pos + i]);
+
+                    }
+                }
+                break;
+            }
+        }
+
+        pos += length;
+    }
+}
+
+/** @} */ /* End of group CENTRAL_CLIENT_GAP_CALLBACK */
+/** @defgroup  GCS_CLIIENT_CALLBACK GCS Client Callback Event Handler
+    * @brief Handle profile client callback event
+    * @{
+    */
+void ble_matter_adapter_gcs_handle_discovery_result(uint8_t conn_id, T_GCS_DISCOVERY_RESULT discov_result)
+{
+	uint16_t i;
+	T_GCS_DISCOV_RESULT *p_result_table;
+	uint16_t    properties;
+	switch (discov_result.discov_type) {
+	case GCS_ALL_PRIMARY_SRV_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_ALL_PRIMARY_SRV_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_ALL_SRV_UUID16:
+				APP_PRINT_INFO4("ALL SRV UUID16[%d]: service range: 0x%x-0x%x, uuid16 0x%x",
+								i, p_result_table->result_data.srv_uuid16_disc_data.att_handle,
+								p_result_table->result_data.srv_uuid16_disc_data.end_group_handle,
+								p_result_table->result_data.srv_uuid16_disc_data.uuid16);
+				printf("ALL SRV UUID16[%d]: service range: 0x%x-0x%x, uuid16 0x%x\r\n",
+					   i, p_result_table->result_data.srv_uuid16_disc_data.att_handle,
+					   p_result_table->result_data.srv_uuid16_disc_data.end_group_handle,
+					   p_result_table->result_data.srv_uuid16_disc_data.uuid16);
+
+				break;
+			case DISC_RESULT_ALL_SRV_UUID128:
+				APP_PRINT_INFO4("ALL SRV UUID128[%d]: service range: 0x%x-0x%x, service=<%b>",
+								i, p_result_table->result_data.srv_uuid128_disc_data.att_handle,
+								p_result_table->result_data.srv_uuid128_disc_data.end_group_handle,
+								TRACE_BINARY(16, p_result_table->result_data.srv_uuid128_disc_data.uuid128));
+				printf("ALL SRV UUID128[%d]: service range: 0x%x-0x%x, service="UUID_128_FORMAT"\n\r",
+					   i, p_result_table->result_data.srv_uuid128_disc_data.att_handle,
+					   p_result_table->result_data.srv_uuid128_disc_data.end_group_handle,
+					   UUID_128(p_result_table->result_data.srv_uuid128_disc_data.uuid128));
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	case GCS_BY_UUID128_SRV_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_BY_UUID128_SRV_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_BY_UUID128_SRV_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_SRV_DATA:
+				APP_PRINT_INFO3("SRV DATA[%d]: service range: 0x%x-0x%x",
+								i, p_result_table->result_data.srv_disc_data.att_handle,
+								p_result_table->result_data.srv_disc_data.end_group_handle);
+				printf("SRV DATA[%d]: service range: 0x%x-0x%x\n\r",
+					   i, p_result_table->result_data.srv_disc_data.att_handle,
+					   p_result_table->result_data.srv_disc_data.end_group_handle);
+
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	case GCS_BY_UUID_SRV_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_BY_UUID_SRV_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_BY_UUID_SRV_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_SRV_DATA:
+				APP_PRINT_INFO3("SRV DATA[%d]: service range: 0x%x-0x%x",
+								i, p_result_table->result_data.srv_disc_data.att_handle,
+								p_result_table->result_data.srv_disc_data.end_group_handle);
+				printf("SRV DATA[%d]: service range: 0x%x-0x%x\n\r",
+					   i, p_result_table->result_data.srv_disc_data.att_handle,
+					   p_result_table->result_data.srv_disc_data.end_group_handle);
+
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	case GCS_ALL_CHAR_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_ALL_CHAR_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_ALL_CHAR_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_CHAR_UUID16:
+				properties = p_result_table->result_data.char_uuid16_disc_data.properties;
+				APP_PRINT_INFO5("CHAR UUID16[%d]: decl_handle 0x%x, properties 0x%x, value_handle 0x%x, uuid16 0x%x",
+								i, p_result_table->result_data.char_uuid16_disc_data.decl_handle,
+								p_result_table->result_data.char_uuid16_disc_data.properties,
+								p_result_table->result_data.char_uuid16_disc_data.value_handle,
+								p_result_table->result_data.char_uuid16_disc_data.uuid16);
+				APP_PRINT_INFO5("properties:indicate %d, read %d, write cmd %d, write %d, notify %d\r\n",
+								properties & GATT_CHAR_PROP_INDICATE,
+								properties & GATT_CHAR_PROP_READ,
+								properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+								properties & GATT_CHAR_PROP_WRITE,
+								properties & GATT_CHAR_PROP_NOTIFY);
+				printf("CHAR UUID16[%d]: decl_handle 0x%x, properties 0x%x, value_handle 0x%x, uuid16 0x%x\n\r",
+					   i, p_result_table->result_data.char_uuid16_disc_data.decl_handle,
+					   p_result_table->result_data.char_uuid16_disc_data.properties,
+					   p_result_table->result_data.char_uuid16_disc_data.value_handle,
+					   p_result_table->result_data.char_uuid16_disc_data.uuid16);
+				printf("properties:indicate %d, read %d, write cmd %d, write %d, notify %d\n\r",
+					   properties & GATT_CHAR_PROP_INDICATE,
+					   properties & GATT_CHAR_PROP_READ,
+					   properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+					   properties & GATT_CHAR_PROP_WRITE,
+					   properties & GATT_CHAR_PROP_NOTIFY);
+				
+				break;
+
+			case DISC_RESULT_CHAR_UUID128:
+				properties = p_result_table->result_data.char_uuid128_disc_data.properties;
+				APP_PRINT_INFO5("CHAR UUID128[%d]:  decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid128=<%b>",
+								i, p_result_table->result_data.char_uuid128_disc_data.decl_handle,
+								p_result_table->result_data.char_uuid128_disc_data.properties,
+								p_result_table->result_data.char_uuid128_disc_data.value_handle,
+								TRACE_BINARY(16, p_result_table->result_data.char_uuid128_disc_data.uuid128));
+				APP_PRINT_INFO5("properties:indicate %d, read %d, write cmd %d, write %d, notify %d",
+								properties & GATT_CHAR_PROP_INDICATE,
+								properties & GATT_CHAR_PROP_READ,
+								properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+								properties & GATT_CHAR_PROP_WRITE,
+								properties & GATT_CHAR_PROP_NOTIFY
+							   );
+				printf("CHAR UUID128[%d]:  decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid128="UUID_128_FORMAT"\n\r",
+					   i, p_result_table->result_data.char_uuid128_disc_data.decl_handle,
+					   p_result_table->result_data.char_uuid128_disc_data.properties,
+					   p_result_table->result_data.char_uuid128_disc_data.value_handle,
+					   UUID_128(p_result_table->result_data.char_uuid128_disc_data.uuid128));
+				printf("properties:indicate %d, read %d, write cmd %d, write %d, notify %d\n\r",
+					   properties & GATT_CHAR_PROP_INDICATE,
+					   properties & GATT_CHAR_PROP_READ,
+					   properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+					   properties & GATT_CHAR_PROP_WRITE,
+					   properties & GATT_CHAR_PROP_NOTIFY
+					  );
+				break;
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	case GCS_BY_UUID_CHAR_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_BY_UUID_CHAR_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_BY_UUID_CHAR_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_BY_UUID16_CHAR:
+				properties = p_result_table->result_data.char_uuid16_disc_data.properties;
+				APP_PRINT_INFO5("UUID16 CHAR[%d]: Characteristics by uuid16, decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid16=<0x%x>",
+								i, p_result_table->result_data.char_uuid16_disc_data.decl_handle,
+								p_result_table->result_data.char_uuid16_disc_data.properties,
+								p_result_table->result_data.char_uuid16_disc_data.value_handle,
+								p_result_table->result_data.char_uuid16_disc_data.uuid16);
+				APP_PRINT_INFO5("properties:indicate %d, read %d, write cmd %d, write %d, notify %d",
+								properties & GATT_CHAR_PROP_INDICATE,
+								properties & GATT_CHAR_PROP_READ,
+								properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+								properties & GATT_CHAR_PROP_WRITE,
+								properties & GATT_CHAR_PROP_NOTIFY
+							   );
+				printf("UUID16 CHAR[%d]: Characteristics by uuid16, decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid16=<0x%x>\n\r",
+					   i, p_result_table->result_data.char_uuid16_disc_data.decl_handle,
+					   p_result_table->result_data.char_uuid16_disc_data.properties,
+					   p_result_table->result_data.char_uuid16_disc_data.value_handle,
+					   p_result_table->result_data.char_uuid16_disc_data.uuid16);
+				printf("properties:indicate %d, read %d, write cmd %d, write %d, notify %d\n\r",
+					   properties & GATT_CHAR_PROP_INDICATE,
+					   properties & GATT_CHAR_PROP_READ,
+					   properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+					   properties & GATT_CHAR_PROP_WRITE,
+					   properties & GATT_CHAR_PROP_NOTIFY
+					  );
+
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!");
+				break;
+			}
+		}
+		break;
+
+	case GCS_BY_UUID128_CHAR_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_BY_UUID128_CHAR_DISCOV, is_success %d",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_BY_UUID128_CHAR_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_BY_UUID128_CHAR:
+				properties = p_result_table->result_data.char_uuid128_disc_data.properties;
+				APP_PRINT_INFO5("UUID128 CHAR[%d]: Characteristics by uuid128, decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid128=<%b>",
+								i, p_result_table->result_data.char_uuid128_disc_data.decl_handle,
+								p_result_table->result_data.char_uuid128_disc_data.properties,
+								p_result_table->result_data.char_uuid128_disc_data.value_handle,
+								TRACE_BINARY(16, p_result_table->result_data.char_uuid128_disc_data.uuid128));
+				APP_PRINT_INFO5("properties:indicate %d, read %d, write cmd %d, write %d, notify %d",
+								properties & GATT_CHAR_PROP_INDICATE,
+								properties & GATT_CHAR_PROP_READ,
+								properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+								properties & GATT_CHAR_PROP_WRITE,
+								properties & GATT_CHAR_PROP_NOTIFY
+							   );
+				printf("UUID128 CHAR[%d]: Characteristics by uuid128, decl hndl=0x%x, prop=0x%x, value hndl=0x%x, uuid128="UUID_128_FORMAT"\n\r",
+					   i, p_result_table->result_data.char_uuid128_disc_data.decl_handle,
+					   p_result_table->result_data.char_uuid128_disc_data.properties,
+					   p_result_table->result_data.char_uuid128_disc_data.value_handle,
+					   UUID_128(p_result_table->result_data.char_uuid128_disc_data.uuid128));
+				printf("properties:indicate %d, read %d, write cmd %d, write %d, notify %d\n\r",
+					   properties & GATT_CHAR_PROP_INDICATE,
+					   properties & GATT_CHAR_PROP_READ,
+					   properties & GATT_CHAR_PROP_WRITE_NO_RSP,
+					   properties & GATT_CHAR_PROP_WRITE,
+					   properties & GATT_CHAR_PROP_NOTIFY
+					  );
+
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				BLE_PRINT("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	case GCS_ALL_CHAR_DESC_DISCOV:
+		APP_PRINT_INFO2("conn_id %d, GCS_ALL_CHAR_DESC_DISCOV, is_success %d\r\n",
+						conn_id, discov_result.is_success);
+		printf("conn_id %d, GCS_ALL_CHAR_DESC_DISCOV, is_success %d\n\r",
+			   conn_id, discov_result.is_success);
+		for (i = 0; i < discov_result.result_num; i++) {
+			p_result_table = &(discov_result.p_result_table[i]);
+			switch (p_result_table->result_type) {
+			case DISC_RESULT_CHAR_DESC_UUID16:
+				APP_PRINT_INFO3("DESC UUID16[%d]: Descriptors handle=0x%x, uuid16=<0x%x>",
+								i, p_result_table->result_data.char_desc_uuid16_disc_data.handle,
+								p_result_table->result_data.char_desc_uuid16_disc_data.uuid16);
+				printf("DESC UUID16[%d]: Descriptors handle=0x%x, uuid16=<0x%x>\n\r",
+					   i, p_result_table->result_data.char_desc_uuid16_disc_data.handle,
+					   p_result_table->result_data.char_desc_uuid16_disc_data.uuid16);
+				
+				break;
+			case DISC_RESULT_CHAR_DESC_UUID128:
+				APP_PRINT_INFO3("DESC UUID128[%d]: Descriptors handle=0x%x, uuid128=<%b>",
+								i, p_result_table->result_data.char_desc_uuid128_disc_data.handle,
+								TRACE_BINARY(16, p_result_table->result_data.char_desc_uuid128_disc_data.uuid128));
+				printf("DESC UUID128[%d]: Descriptors handle=0x%x, uuid128="UUID_128_FORMAT"\n\r",
+					   i, p_result_table->result_data.char_desc_uuid128_disc_data.handle,
+					   UUID_128(p_result_table->result_data.char_desc_uuid128_disc_data.uuid128));
+				
+				break;
+
+			default:
+				APP_PRINT_ERROR0("Invalid Discovery Result Type!");
+				printf("Invalid Discovery Result Type!\n\r");
+				break;
+			}
+		}
+		break;
+
+	default:
+		APP_PRINT_ERROR2("Invalid disc type: conn_id %d, discov_type %d",
+						 conn_id, discov_result.discov_type);
+		printf("Invalid disc type: conn_id %d, discov_type %d\n\r",
+			   conn_id, discov_result.discov_type);
+		break;
+	}
+}
+/**
+ * @brief  Callback will be called when data sent from gcs client.
+ * @param  client_id the ID distinguish which module sent the data.
+ * @param  conn_id connection ID.
+ * @param  p_data  pointer to data.
+ * @retval   result @ref T_APP_RESULT
+ */
+T_APP_RESULT ble_matter_adapter_gcs_client_callback(T_CLIENT_ID client_id, uint8_t conn_id, void *p_data)
+{
+	T_APP_RESULT  result = APP_RESULT_SUCCESS;
+	APP_PRINT_INFO2("ble_matter_adapter_gcs_client_callback: client_id %d, conn_id %d",
+					client_id, conn_id);
+	if (client_id == ble_matter_adapter_gcs_client_id) {
+		T_GCS_CLIENT_CB_DATA *p_gcs_cb_data = (T_GCS_CLIENT_CB_DATA *)p_data;
+		switch (p_gcs_cb_data->cb_type) {
+		case GCS_CLIENT_CB_TYPE_DISC_RESULT:
+			ble_matter_adapter_gcs_handle_discovery_result(conn_id, p_gcs_cb_data->cb_content.discov_result);
+			break;
+		case GCS_CLIENT_CB_TYPE_READ_RESULT:
+			APP_PRINT_INFO3("READ RESULT: cause 0x%x, handle 0x%x, value_len %d",
+							p_gcs_cb_data->cb_content.read_result.cause,
+							p_gcs_cb_data->cb_content.read_result.handle,
+							p_gcs_cb_data->cb_content.read_result.value_size);
+			printf("READ RESULT: cause 0x%x, handle 0x%x, value_len %d\n\r",
+				   p_gcs_cb_data->cb_content.read_result.cause,
+				   p_gcs_cb_data->cb_content.read_result.handle,
+				   p_gcs_cb_data->cb_content.read_result.value_size);
+
+			if (p_gcs_cb_data->cb_content.read_result.cause == GAP_SUCCESS) {
+				APP_PRINT_INFO1("READ VALUE: %b",
+								TRACE_BINARY(p_gcs_cb_data->cb_content.read_result.value_size,
+											 p_gcs_cb_data->cb_content.read_result.p_value));
+				printf("READ VALUE: ");
+				for (int i = 0; i < p_gcs_cb_data->cb_content.read_result.value_size; i++) {
+					printf("0x%2x ", *(p_gcs_cb_data->cb_content.read_result.p_value + i));
+				}
+				printf("\n\r");
+			}
+
+			break;
+		case GCS_CLIENT_CB_TYPE_WRITE_RESULT:
+			APP_PRINT_INFO3("WRITE RESULT: cause 0x%x, handle 0x%x, type %d",
+							p_gcs_cb_data->cb_content.write_result.cause,
+							p_gcs_cb_data->cb_content.write_result.handle,
+							p_gcs_cb_data->cb_content.write_result.type);
+			printf("WRITE RESULT: cause 0x%x, handle 0x%x, type %d\n\r",
+				   p_gcs_cb_data->cb_content.write_result.cause,
+				   p_gcs_cb_data->cb_content.write_result.handle,
+				   p_gcs_cb_data->cb_content.write_result.type);
+			break;
+		case GCS_CLIENT_CB_TYPE_NOTIF_IND:
+			if (p_gcs_cb_data->cb_content.notif_ind.notify == false) {
+				APP_PRINT_INFO2("INDICATION: handle 0x%x, value_size %d",
+								p_gcs_cb_data->cb_content.notif_ind.handle,
+								p_gcs_cb_data->cb_content.notif_ind.value_size);
+				APP_PRINT_INFO1("INDICATION VALUE: %b",
+								TRACE_BINARY(p_gcs_cb_data->cb_content.notif_ind.value_size,
+											 p_gcs_cb_data->cb_content.notif_ind.p_value));
+				printf("INDICATION: handle 0x%x, value_size %d\r\n",
+					   p_gcs_cb_data->cb_content.notif_ind.handle,
+					   p_gcs_cb_data->cb_content.notif_ind.value_size);
+				printf("INDICATION VALUE: ");
+				for (int i = 0; i < p_gcs_cb_data->cb_content.notif_ind.value_size; i++) {
+					printf("0x%2x ", *(p_gcs_cb_data->cb_content.notif_ind.p_value + i));
+				}
+				printf("\n\r");
+			} else {
+				APP_PRINT_INFO2("NOTIFICATION: handle 0x%x, value_size %d",
+								p_gcs_cb_data->cb_content.notif_ind.handle,
+								p_gcs_cb_data->cb_content.notif_ind.value_size);
+				APP_PRINT_INFO1("NOTIFICATION VALUE: %b",
+								TRACE_BINARY(p_gcs_cb_data->cb_content.notif_ind.value_size,
+											 p_gcs_cb_data->cb_content.notif_ind.p_value));
+				printf("NOTIFICATION: handle 0x%x, value_size %d\r\n",
+					   p_gcs_cb_data->cb_content.notif_ind.handle,
+					   p_gcs_cb_data->cb_content.notif_ind.value_size);
+				printf("NOTIFICATION VALUE: ");
+				for (int i = 0; i < p_gcs_cb_data->cb_content.notif_ind.value_size; i++) {
+					printf("0x%2x ", *(p_gcs_cb_data->cb_content.notif_ind.p_value + i));
+				}
+				printf("\n\r");
+			}
+			break;
+		default:
+			break;
+		}
+	}
+
+	return result;
+}
+
+/**
+  * @brief Callback for gap le to notify app
+  * @param[in] cb_type callback msy type @ref GAP_LE_MSG_Types.
+  * @param[in] p_cb_data point to callback data @ref T_LE_CB_DATA.
+  * @retval result @ref T_APP_RESULT
+  */
+T_APP_RESULT ble_matter_adapter_app_gap_callback(uint8_t cb_type, void *p_cb_data)
+{
+	T_APP_RESULT result = APP_RESULT_SUCCESS;
+	T_LE_CB_DATA *p_data = (T_LE_CB_DATA *)p_cb_data;
+	char adv_type[20];
+	char remote_addr_type[10];
+
+	switch (cb_type) {
+	    /* common msg*/
+	    case GAP_MSG_LE_READ_RSSI:
+		APP_PRINT_INFO3("GAP_MSG_LE_READ_RSSI:conn_id 0x%x cause 0x%x rssi %d",
+		                p_data->p_le_read_rssi_rsp->conn_id,
+		                p_data->p_le_read_rssi_rsp->cause,
+		                p_data->p_le_read_rssi_rsp->rssi);
+		break;
+
+	    case GAP_MSG_LE_BOND_MODIFY_INFO:
+		APP_PRINT_INFO1("GAP_MSG_LE_BOND_MODIFY_INFO: type 0x%x",
+		                p_data->p_le_bond_modify_info->type);
+		break;
+
+	/* central reference msg*/
+	    case GAP_MSG_LE_SCAN_INFO:
+		APP_PRINT_INFO5("GAP_MSG_LE_SCAN_INFO:adv_type 0x%x, bd_addr %s, remote_addr_type %d, rssi %d, data_len %d",
+		                p_data->p_le_scan_info->adv_type,
+		                TRACE_BDADDR(p_data->p_le_scan_info->bd_addr),
+		                p_data->p_le_scan_info->remote_addr_type,
+		                p_data->p_le_scan_info->rssi,
+		                p_data->p_le_scan_info->data_len);
+
+		if (bt_matter_device_matter_scan_state) {
+		    /* If you want to parse the scan info, please reference function ble_central_app_parse_scan_info. */
+		    sprintf(adv_type,"%s",(p_data->p_le_scan_info->adv_type ==GAP_ADV_EVT_TYPE_UNDIRECTED)? "CON_UNDIRECT":
+		                          (p_data->p_le_scan_info->adv_type ==GAP_ADV_EVT_TYPE_DIRECTED)? "CON_DIRECT":
+		                          (p_data->p_le_scan_info->adv_type ==GAP_ADV_EVT_TYPE_SCANNABLE)? "SCANABLE_UNDIRCT":
+		                          (p_data->p_le_scan_info->adv_type ==GAP_ADV_EVT_TYPE_NON_CONNECTABLE)? "NON_CONNECTABLE":
+		                          (p_data->p_le_scan_info->adv_type ==GAP_ADV_EVT_TYPE_SCAN_RSP)? "SCAN_RSP":"unknown");
+		    sprintf(remote_addr_type,"%s",(p_data->p_le_scan_info->remote_addr_type == GAP_REMOTE_ADDR_LE_PUBLIC)? "public":
+		                          (p_data->p_le_scan_info->remote_addr_type == GAP_REMOTE_ADDR_LE_RANDOM)? "random":"unknown");
+
+		    BLE_PRINT("ADVType\t\t\t| AddrType\t|%s\t\t\t|rssi\n\r","BT_Addr");
+		    BLE_PRINT("%s\t\t%s\t"BD_ADDR_FMT"\t%d\n\r",adv_type,remote_addr_type,BD_ADDR_ARG(p_data->p_le_scan_info->bd_addr),
+		                                            p_data->p_le_scan_info->rssi);
+
+		    bt_matter_device_matter_app_parse_scan_info(p_data->p_le_scan_info);
+		}
+		//gap_sched_handle_adv_report(p_data->p_le_scan_info);
+		break;
+
+
+	#if F_BT_LE_4_2_DATA_LEN_EXT_SUPPORT
+	    case GAP_MSG_LE_DATA_LEN_CHANGE_INFO:
+		APP_PRINT_INFO3("GAP_MSG_LE_DATA_LEN_CHANGE_INFO: conn_id %d, tx octets 0x%x, max_tx_time 0x%x",
+		                p_data->p_le_data_len_change_info->conn_id,
+		                p_data->p_le_data_len_change_info->max_tx_octets,
+		                p_data->p_le_data_len_change_info->max_tx_time);
+		break;
+	#endif
+
+	#if F_BT_LE_GAP_CENTRAL_SUPPORT
+	    case GAP_MSG_LE_CONN_UPDATE_IND:
+		APP_PRINT_INFO5("GAP_MSG_LE_CONN_UPDATE_IND: conn_id %d, conn_interval_max 0x%x, conn_interval_min 0x%x, conn_latency 0x%x,supervision_timeout 0x%x",
+		                p_data->p_le_conn_update_ind->conn_id,
+		                p_data->p_le_conn_update_ind->conn_interval_max,
+		                p_data->p_le_conn_update_ind->conn_interval_min,
+		                p_data->p_le_conn_update_ind->conn_latency,
+		                p_data->p_le_conn_update_ind->supervision_timeout);
+		/* if reject the proposed connection parameter from peer device, use APP_RESULT_REJECT. */
+		result = APP_RESULT_ACCEPT;
+		break;
+
+	    case GAP_MSG_LE_SET_HOST_CHANN_CLASSIF:
+		APP_PRINT_INFO1("GAP_MSG_LE_SET_HOST_CHANN_CLASSIF: cause 0x%x",
+		                p_data->p_le_set_host_chann_classif_rsp->cause);
+		break;
+	#endif
+#if F_BT_LE_5_0_SET_PHY_SUPPORT
+	case GAP_MSG_LE_PHY_UPDATE_INFO:
+		APP_PRINT_INFO4("GAP_MSG_LE_PHY_UPDATE_INFO:conn_id %d, cause 0x%x, rx_phy %d, tx_phy %d",
+						p_data->p_le_phy_update_info->conn_id,
+						p_data->p_le_phy_update_info->cause,
+						p_data->p_le_phy_update_info->rx_phy,
+						p_data->p_le_phy_update_info->tx_phy);
+		printf("GAP_MSG_LE_PHY_UPDATE_INFO:conn_id %d, cause 0x%x, rx_phy %d, tx_phy %d\n\r",
+			   p_data->p_le_phy_update_info->conn_id,
+			   p_data->p_le_phy_update_info->cause,
+			   p_data->p_le_phy_update_info->rx_phy,
+			   p_data->p_le_phy_update_info->tx_phy);
+
+		break;
+
+	case GAP_MSG_LE_REMOTE_FEATS_INFO: {
+		uint8_t  remote_feats[8];
+		APP_PRINT_INFO3("GAP_MSG_LE_REMOTE_FEATS_INFO: conn id %d, cause 0x%x, remote_feats %b",
+						p_data->p_le_remote_feats_info->conn_id,
+						p_data->p_le_remote_feats_info->cause,
+						TRACE_BINARY(8, p_data->p_le_remote_feats_info->remote_feats));
+		if (p_data->p_le_remote_feats_info->cause == GAP_SUCCESS) {
+			memcpy(remote_feats, p_data->p_le_remote_feats_info->remote_feats, 8);
+			if (remote_feats[LE_SUPPORT_FEATURES_MASK_ARRAY_INDEX1] & LE_SUPPORT_FEATURES_LE_2M_MASK_BIT) {
+				APP_PRINT_INFO0("GAP_MSG_LE_REMOTE_FEATS_INFO: support 2M");
+				printf("GAP_MSG_LE_REMOTE_FEATS_INFO: support 2M\n\r");
+			}
+			if (remote_feats[LE_SUPPORT_FEATURES_MASK_ARRAY_INDEX1] & LE_SUPPORT_FEATURES_LE_CODED_PHY_MASK_BIT) {
+				APP_PRINT_INFO0("GAP_MSG_LE_REMOTE_FEATS_INFO: support CODED");
+				printf("GAP_MSG_LE_REMOTE_FEATS_INFO: support CODED\n\r");
+			}
+		}
+	}
+	break;
+#endif
+
+	case GAP_MSG_LE_MODIFY_WHITE_LIST:
+		APP_PRINT_INFO2("GAP_MSG_LE_MODIFY_WHITE_LIST: operation  0x%x, cause 0x%x",
+						p_data->p_le_modify_white_list_rsp->operation,
+						p_data->p_le_modify_white_list_rsp->cause);
+		printf("GAP_MSG_LE_MODIFY_WHITE_LIST: operation  0x%x, cause 0x%x\r\n",
+			   p_data->p_le_modify_white_list_rsp->operation,
+			   p_data->p_le_modify_white_list_rsp->cause);
+		break;
+
+	case GAP_MSG_LE_ADV_UPDATE_PARAM:
+		APP_PRINT_INFO1("GAP_MSG_LE_ADV_UPDATE_PARAM: cause 0x%x",
+					  p_data->p_le_adv_update_param_rsp->cause);
+		//printf("GAP_MSG_LE_ADV_UPDATE_PARAM: cause 0x%x\r\n",
+					 // p_data->p_le_adv_update_param_rsp->cause);
+#if CONFIG_BLE_MATTER_MULTI_ADV
+		if (p_data->p_le_adv_update_param_rsp->cause == 0) {
+			uint8_t adv_stop_flag = 0;
+			adv_stop_flag = ble_matter_adapter_judge_adv_stop(matter_multi_adapter.adv_id);
+			if (adv_stop_flag) {
+				printf("[%s]stop adv flag[%d] is set, give sem and break\r\n", __func__, matter_multi_adapter.adv_id);
+				matter_multi_adapter.adv_id = MAX_ADV_NUMBER;
+				if(matter_multi_adapter.sem_handle)
+					os_sem_give(matter_multi_adapter.sem_handle);
+				break;
+			}
+#if BT_VENDOR_CMD_ONE_SHOT_SUPPORT
+			T_GAP_CAUSE ret = GAP_CAUSE_SUCCESS;
+			ret = le_vendor_one_shot_adv();
+			if (ret != GAP_CAUSE_SUCCESS) {
+				printf(" fail! ret = 0x%x\r\n", ret);
+			}
+#endif
+		}
+#endif
+		APP_PRINT_INFO1("GAP_MSG_LE_ADV_UPDATE_PARAM: cause 0x%x",
+		                p_data->p_le_adv_update_param_rsp->cause);
+		//gap_sched_adv_params_set_done();
+		break;
+
+	default:
+		APP_PRINT_ERROR1("ble_matter_adapter_app_gap_callback: unhandled cb_type 0x%x", cb_type);
+		break;
+	}
+	return result;
+}
+/**
+ * @brief  Callback will be called when data sent from profile client layer.
+ * @param  client_id the ID distinguish which module sent the data.
+ * @param  conn_id connection ID.
+ * @param  p_data  pointer to data.
+ * @retval   result @ref T_APP_RESULT
+ */
+T_APP_RESULT ble_matter_adapter_app_client_callback(T_CLIENT_ID client_id, uint8_t conn_id, void *p_data)
+{
+    T_APP_RESULT  result = APP_RESULT_SUCCESS;
+    APP_PRINT_INFO2("bt_mesh_device_matter_app_client_callback: client_id %d, conn_id %d",
+                    client_id, conn_id);
+    if (client_id == CLIENT_PROFILE_GENERAL_ID)
+    {
+        T_CLIENT_APP_CB_DATA *p_client_app_cb_data = (T_CLIENT_APP_CB_DATA *)p_data;
+        switch (p_client_app_cb_data->cb_type)
+        {
+        case CLIENT_APP_CB_TYPE_DISC_STATE:
+            if (p_client_app_cb_data->cb_content.disc_state_data.disc_state == DISC_STATE_SRV_DONE)
+            {
+                APP_PRINT_INFO0("Discovery All Service Procedure Done.");
+            }
+            else
+            {
+                APP_PRINT_INFO0("Discovery state send to application directly.");
+            }
+            break;
+        case CLIENT_APP_CB_TYPE_DISC_RESULT:
+            if (p_client_app_cb_data->cb_content.disc_result_data.result_type == DISC_RESULT_ALL_SRV_UUID16)
+            {
+                APP_PRINT_INFO3("Discovery All Primary Service: UUID16 0x%x, start handle 0x%x, end handle 0x%x.",
+                                p_client_app_cb_data->cb_content.disc_result_data.result_data.p_srv_uuid16_disc_data->uuid16,
+                                p_client_app_cb_data->cb_content.disc_result_data.result_data.p_srv_uuid16_disc_data->att_handle,
+                                p_client_app_cb_data->cb_content.disc_result_data.result_data.p_srv_uuid16_disc_data->end_group_handle);
+            }
+            else
+            {
+                APP_PRINT_INFO0("Discovery result send to application directly.");
+            }
+            break;
+        default:
+            break;
+        }
+
+    }
+    return result;
+}
+
+/** @defgroup  PERIPH_SEVER_CALLBACK Profile Server Callback Event Handler
+    * @brief Handle profile server callback event
+    * @{
+    */
+/**
+    * @brief    All the BT Profile service callback events are handled in this function
+    * @note     Then the event handling function shall be called according to the
+    *           service_id
+    * @param    service_id  Profile service ID
+    * @param    p_data      Pointer to callback data
+    * @return   T_APP_RESULT, which indicates the function call is successful or not
+    * @retval   APP_RESULT_SUCCESS  Function run successfully
+    * @retval   others              Function run failed, and return number indicates the reason
+    */
+T_APP_RESULT ble_matter_adapter_app_profile_callback(T_SERVER_ID service_id, void *p_data)
+{
+	T_APP_RESULT app_result = APP_RESULT_SUCCESS;
+	if (service_id == SERVICE_PROFILE_GENERAL_ID) {
+		T_SERVER_APP_CB_DATA *p_param = (T_SERVER_APP_CB_DATA *)p_data;
+		switch (p_param->eventId) {
+		case PROFILE_EVT_SRV_REG_COMPLETE:// srv register result event.
+			APP_PRINT_INFO1("PROFILE_EVT_SRV_REG_COMPLETE: result %d",
+							p_param->event_data.service_reg_result);
+			break;
+		case PROFILE_EVT_SEND_DATA_COMPLETE:
+			APP_PRINT_INFO5("PROFILE_EVT_SEND_DATA_COMPLETE: conn_id %d, cause 0x%x, service_id %d, attrib_idx 0x%x, credits %d",
+							p_param->event_data.send_data_result.conn_id,
+							p_param->event_data.send_data_result.cause,
+							p_param->event_data.send_data_result.service_id,
+							p_param->event_data.send_data_result.attrib_idx,
+							p_param->event_data.send_data_result.credits);
+			printf("PROFILE_EVT_SEND_DATA_COMPLETE: conn_id %d, cause 0x%x, service_id %d, attrib_idx 0x%x, credits %d\r\n",
+				   p_param->event_data.send_data_result.conn_id,
+				   p_param->event_data.send_data_result.cause,
+				   p_param->event_data.send_data_result.service_id,
+				   p_param->event_data.send_data_result.attrib_idx,
+				   p_param->event_data.send_data_result.credits);
+			if (p_param->event_data.send_data_result.cause == GAP_SUCCESS) {
+				APP_PRINT_INFO0("PROFILE_EVT_SEND_DATA_COMPLETE success");
+				printf("PROFILE_EVT_SEND_DATA_COMPLETE success\r\n");
+//send msg to matter
+#if CONFIG_BLE_MATTER_MULTI_ADV
+				if (p_param->event_data.send_data_result.service_id == ble_matter_adapter_service_id) {
+					T_MATTER_BLEMGR_TX_COMPLETE_CB_ARG *indication_complete_msg_matter = (T_MATTER_BLEMGR_TX_COMPLETE_CB_ARG *) os_mem_alloc(0, sizeof(T_MATTER_BLEMGR_TX_COMPLETE_CB_ARG));
+					memset(indication_complete_msg_matter, 0, sizeof(T_MATTER_BLEMGR_TX_COMPLETE_CB_ARG));
+					indication_complete_msg_matter->conn_id = p_param->event_data.send_data_result.conn_id;
+					
+					if (ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_SEND_DATA_COMPLETE_MULTI_ADV, NULL,indication_complete_msg_matter) == false) {
+						printf("\n\r[%s] send callback msg fail\r\n", __func__);
+						os_mem_free(indication_complete_msg_matter);
+					}
+				}
+#else
+        		if (p_param->event_data.send_data_result.service_id == ble_matter_adapter_service_id)
+        		{
+                    T_SERVER_APP_CB_DATA *send_data_complete = os_mem_alloc(0, sizeof(T_SERVER_APP_CB_DATA));
+				    if(send_data_complete)
+				    {
+					    memcpy(send_data_complete, p_param, sizeof(T_SERVER_APP_CB_DATA));
+					    if(ble_matter_adapter_send_callback_msg(BT_MATTER_SEND_CB_MSG_SEND_DATA_COMPLETE, service_id, send_data_complete)==false)
+					    {
+					        os_mem_free(send_data_complete);
+					    }
+				    }
+				else
+					printf("Malloc failed\r\n");
+			    }
+#endif	
+			} else {
+				APP_PRINT_ERROR0("PROFILE_EVT_SEND_DATA_COMPLETE failed");
+				printf("PROFILE_EVT_SEND_DATA_COMPLETE failed\r\n");
+			}
+			break;
+
+		default:
+			break;
+		}
+	} else if (service_id == ble_matter_adapter_service_id) {
+		
+        T_MATTER_CALLBACK_DATA *p_ms_cb_data = (T_MATTER_CALLBACK_DATA *)p_data;
+
+        switch (p_ms_cb_data->msg_type)
+        {
+	
+        case SERVICE_CALLBACK_TYPE_INDIFICATION_NOTIFICATION:
+           {
+
+                switch (p_ms_cb_data->msg_data.notification_indification_index)
+                {
+                case MATTER_NOTIFY_INDICATE_V3_ENABLE:
+                    {
+                        APP_PRINT_INFO0("MATTER_NOTIFY_INDICATE_V3_ENABLE");
+                        printf("\n\rMATTER_NOTIFY_INDICATE_V3_ENABLE\r\n");
+                        //send msg to matter
+                        T_MATTER_CALLBACK_DATA *indication_notification_enable = os_mem_alloc(0, sizeof(T_MATTER_CALLBACK_DATA));
+
+                        if(indication_notification_enable)
+                        {
+                            memcpy(indication_notification_enable, p_ms_cb_data, sizeof(T_MATTER_CALLBACK_DATA));
+                            printf("L2055,BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE=%d\r\n",BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE);
+                            //if(ble_matter_adapter_send_callback_msg(BMS_CALLBACK_MSG_CMP_CCCD_RECV_ENABLE_MATTER, service_id, indication_notification_enable)==false)
+                            if(ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_CCCD_RECV_ENABLE_MULTI_ADV, service_id, indication_notification_enable)==false)
+                            {
+                                os_mem_free(indication_notification_enable);
+                                indication_notification_enable = NULL;
+                            }
+                        }
+                        else
+                            printf("Malloc failed\r\n");
+                    }
+                    break;
+
+                case MATTER_NOTIFY_INDICATE_V3_DISABLE:
+                    {
+                        APP_PRINT_INFO0("MATTER_NOTIFY_INDICATE_V3_DISABLE");
+                        printf("\n\rMATTER_NOTIFY_INDICATE_V3_DISABLE\r\n");
+
+                        //send msg to matter
+                        T_MATTER_CALLBACK_DATA *indication_notification_disable = os_mem_alloc(0, sizeof(T_MATTER_CALLBACK_DATA));
+                        if(indication_notification_disable)
+                        {
+                            memcpy(indication_notification_disable, p_ms_cb_data, sizeof(T_MATTER_CALLBACK_DATA));
+                            //if(ble_matter_adapter_send_callback_msg(BMS_CALLBACK_MSG_CMP_CCCD_RECV_DISABLE_MATTER, service_id, indication_notification_disable)==false)
+			    if(ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_CCCD_RECV_DISABLE_MULTI_ADV, service_id, indication_notification_disable)==false)
+                            {
+                                os_mem_free(indication_notification_disable);
+                                indication_notification_disable = NULL;
+                            }
+                        }
+                        else
+                            printf("Malloc failed\r\n");
+                    }
+                    break;
+                default:
+                    break;
+                }
+
+            }
+            break;
+        case SERVICE_CALLBACK_TYPE_READ_CHAR_VALUE:
+            {
+                T_MATTER_BLEMGR_C3_CHAR_READ_CB_ARG c3_char_read_cb_arg;
+                c3_char_read_cb_arg.pp_value = &p_ms_cb_data->msg_data.write_read.p_value;
+                c3_char_read_cb_arg.p_len = &p_ms_cb_data->msg_data.write_read.len;
+                if (matter_blemgr_callback_func) {
+                    matter_blemgr_callback_func(matter_blemgr_callback_data, MATTER_BLEMGR_C3_CHAR_READ_CB, &c3_char_read_cb_arg);
+                }
+            }
+            break;
+
+        case SERVICE_CALLBACK_TYPE_WRITE_CHAR_VALUE:
+            {
+                //send msg to matter
+                T_MATTER_CALLBACK_DATA *write_char_val = os_mem_alloc(0, sizeof(T_MATTER_CALLBACK_DATA));
+                if(write_char_val)
+                {
+                    memcpy(write_char_val, p_ms_cb_data, sizeof(T_MATTER_CALLBACK_DATA));
+
+                    //Make sure not malloc size of 0
+                    if (write_char_val->msg_data.write_read.len !=0)
+                    {
+                        write_char_val->msg_data.write_read.p_value = os_mem_alloc(0, write_char_val->msg_data.write_read.len);
+                        memcpy(write_char_val->msg_data.write_read.p_value, p_ms_cb_data->msg_data.write_read.p_value, p_ms_cb_data->msg_data.write_read.len);
+                    }
+                    if(ble_matter_adapter_send_callback_msg(BLE_MATTER_MSG_WRITE_CHAR_MULTI_ADV, service_id, write_char_val)==false)
+                    {
+                        if (write_char_val->msg_data.write_read.len !=0)
+                        {
+                            os_mem_free(write_char_val->msg_data.write_read.p_value);
+                            write_char_val->msg_data.write_read.p_value = NULL;
+                        }
+                        os_mem_free(write_char_val);
+                        write_char_val = NULL;
+                    }
+                }
+                else
+                    printf("Malloc failed\r\n");
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    return app_result;
+}
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+void ble_matter_adapter_app_vendor_callback(uint8_t cb_type, void *p_cb_data)
+{
+	T_GAP_VENDOR_CB_DATA cb_data;
+	memcpy(&cb_data, p_cb_data, sizeof(T_GAP_VENDOR_CB_DATA));
+	APP_PRINT_INFO1("app_vendor_callback: command 0x%x", cb_data.p_gap_vendor_cmd_rsp->command);
+	//printf();
+	switch (cb_type)
+	{
+		case GAP_MSG_VENDOR_CMD_RSP:
+			switch(cb_data.p_gap_vendor_cmd_rsp->command)
+			{
+#if BT_VENDOR_CMD_ONE_SHOT_SUPPORT
+				case HCI_LE_VENDOR_EXTENSION_FEATURE2:
+					//if(cb_data.p_gap_vendor_cmd_rsp->param[0] == HCI_EXT_SUB_ONE_SHOT_ADV)
+					{
+						APP_PRINT_ERROR1("One shot adv resp: cause 0x%x", cb_data.p_gap_vendor_cmd_rsp->cause);
+						if (cb_data.p_gap_vendor_cmd_rsp->cause == 0) {
+							if(matter_multi_adapter.sem_handle)
+								os_sem_give(matter_multi_adapter.sem_handle);
+						} else
+							printf("One shot adv resp: cause 0x%x\r\n", cb_data.p_gap_vendor_cmd_rsp->cause);
+					}
+					break;
+#endif
+				default:
+					break;
+			}
+			break;
+
+		default:
+			break;
+	}
+
+	return;
+}
+#endif
+
+#if F_BT_GAPS_CHAR_WRITEABLE
+/** @defgroup  SCATTERNET_GAPS_WRITE GAP Service Callback Handler
+    * @brief Use @ref F_BT_GAPS_CHAR_WRITEABLE to open
+    * @{
+    */
+/**
+ * @brief    All the BT GAP service callback events are handled in this function
+ * @param[in] service_id  Profile service ID
+ * @param[in] p_para      Pointer to callback data
+ * @return   Indicates the function call is successful or not
+ * @retval   result @ref T_APP_RESULT
+ */
+T_APP_RESULT ble_matter_adapter_gap_service_callback(T_SERVER_ID service_id, void *p_para)
+{
+	(void) service_id;
+	T_APP_RESULT  result = APP_RESULT_SUCCESS;
+	T_GAPS_CALLBACK_DATA *p_gap_data = (T_GAPS_CALLBACK_DATA *)p_para;
+	APP_PRINT_INFO2("gap_service_callback: conn_id = %d msg_type = %d\n", p_gap_data->conn_id,
+					p_gap_data->msg_type);
+	APP_PRINT_INFO2("gap_service_callback: len = 0x%x,opcode = %d\n", p_gap_data->msg_data.len,
+					p_gap_data->msg_data.opcode);
+	if (p_gap_data->msg_type == SERVICE_CALLBACK_TYPE_WRITE_CHAR_VALUE) {
+		switch (p_gap_data->msg_data.opcode) {
+		case GAPS_WRITE_DEVICE_NAME: {
+			T_LOCAL_NAME device_name;
+			memcpy(device_name.local_name, p_gap_data->msg_data.p_value, p_gap_data->msg_data.len);
+			device_name.local_name[p_gap_data->msg_data.len] = 0;
+			printf("GAPS_WRITE_DEVICE_NAME:device_name = %s\r\n", device_name.local_name);
+			flash_save_local_name(&device_name);
+		}
+		break;
+
+		case GAPS_WRITE_APPEARANCE: {
+			uint16_t appearance_val;
+			T_LOCAL_APPEARANCE appearance;
+			LE_ARRAY_TO_UINT16(appearance_val, p_gap_data->msg_data.p_value);
+			appearance.local_appearance = appearance_val;
+			//printf("GAPS_WRITE_APPEARANCE:appearance = %s\r\n",appearance.local_appearance);
+			flash_save_local_appearance(&appearance);
+		}
+		break;
+		default:
+			APP_PRINT_ERROR1("gap_service_callback: unhandled msg_data.opcode 0x%x", p_gap_data->msg_data.opcode);
+			//printf("gap_service_callback: unhandled msg_data.opcode 0x%x\r\n", p_gap_data->msg_data.opcode);
+			break;
+		}
+	}
+	return result;
+}
+#endif
+/** @} */ /* End of group PERIPH_SEVER_CALLBACK */
+/** @} */ /* End of group PERIPH_APP */
+#endif

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.c
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.c
@@ -683,12 +683,11 @@ void ble_matter_adapter_app_handle_conn_state_evt(uint8_t conn_id, T_GAP_CONN_ST
 		memset(&ble_matter_adapter_app_link_table[conn_id], 0, sizeof(T_APP_LINK));
 #if CONFIG_BLE_MATTER_MULTI_ADV
 		if (link_customer == 1) { //matter
-        //if(matter_multi_adv_param_array[0].connect_flag == true) {
 			matter_multi_adv_param_array[0].connect_flag = false;
 
-			if(!matter_server_is_commissioned()) {
-				matter_multi_adv_start_by_id(&matter_adv_id, matter_adv_data, matter_adv_data_length, NULL, 0, 1); // the last parameter: 1 for Matter; 2 for Customer
-			}
+			/* Matter ADV will be restarted from Matter upper layer */
+			//matter_multi_adv_start_by_id(&matter_adv_id, matter_adv_data, matter_adv_data_length, NULL, 0, 1); // the last parameter: 1 for Matter; 2 for Customer
+
 #if 1  //send data to matter
 			T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG *disconnected_msg_matter = (T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG *)os_mem_alloc(0, sizeof(T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG));
 			memset(disconnected_msg_matter, 0, sizeof(T_MATTER_BLEMGR_GAP_DISCONNECT_CB_ARG));
@@ -699,12 +698,11 @@ void ble_matter_adapter_app_handle_conn_state_evt(uint8_t conn_id, T_GAP_CONN_ST
 				os_mem_free(disconnected_msg_matter);
 			}
 #endif
-		//}
 		} else if (link_customer == 2) { //customer
-		//if(matter_multi_adv_param_array[1].connect_flag == true) {
-				matter_multi_adv_param_array[1].connect_flag = false;
-				matter_multi_adv_start_by_id(&customer_adv_id, customer_adv_data, customer_adv_data_length, customer_rsp_data, customer_rsp_data_length, 2);
-		//}
+			matter_multi_adv_param_array[1].connect_flag = false;
+
+			/* Customer ADV can be restarted on customer's application */
+			matter_multi_adv_start_by_id(&customer_adv_id, customer_adv_data, customer_adv_data_length, customer_rsp_data, customer_rsp_data_length, 2); // the last parameter: 1 for Matter; 2 for Customer
 		}
 #else
         //send data to matter

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.h
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.h
@@ -1,0 +1,228 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      central_client_app.h
+   * @brief     This file handles BLE central client application routines.
+   * @author    jane
+   * @date      2017-06-06
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+
+#ifndef _BLE_MATTER_ADAPTER_APP_H_
+#define _BLE_MATTER_ADAPTER_APP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*============================================================================*
+ *                              Header Files
+ *============================================================================*/
+#include <profile_client.h>
+#include <app_msg.h>
+#include <profile_server.h>
+#include <gap.h>
+#include <gap_msg.h>
+#include <gcs_client.h>
+#include <gap_conn_le.h>
+#include <ble_matter_adapter_app_flags.h>
+#include "ble_matter_adapter_service.h"
+
+#define BLE_PRINT    printf
+#define BD_ADDR_FMT "%02x:%02x:%02x:%02x:%02x:%02x"
+#define BD_ADDR_ARG(x) (x)[5],(x)[4],(x)[3],(x)[2],(x)[1],(x)[0]
+#define UUID_128_FORMAT "0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X:0x%2X"
+#define UUID_128(x)  x[0],x[1],x[2],x[3],x[4],x[5],x[6],x[7],x[8],x[9],x[10],x[11],x[12],x[13],x[14],x[15]
+
+#define MAX_REGISRABLE_SERVICE_NUMBER 12
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+#define MAX_ADV_NUMBER     2
+#define MATTER_MULTI_TASK_STACK_SIZE  256*10
+#define MATTER_MULTI_TASK_PRIORITY  4
+#define MATTER_MULTI_ADV_DATA_QUEUE_SIZE  0x60
+#endif
+/*============================================================================*
+ *                              Variables
+ *============================================================================*/
+extern T_CLIENT_ID   ble_matter_adapter_gcs_client_id;         /**< General Common Services client client id*/
+
+typedef struct
+{
+	uint8_t conn_id;
+	uint8_t service_id;
+	uint16_t attrib_index;
+	uint8_t *p_data;
+	uint16_t data_len;
+	uint8_t type;
+} BT_MATTER_SERVER_SEND_DATA;
+
+typedef struct
+{
+	uint8_t conn_id;
+	uint8_t new_state;
+	uint16_t disc_cause;
+} BT_MATTER_CONN_EVENT;
+
+typedef struct {
+	T_GAP_CONN_STATE        conn_state;          /**< Connection state. */
+	T_GAP_REMOTE_ADDR_TYPE  bd_type;             /**< remote BD type*/
+	uint8_t                 bd_addr[GAP_BD_ADDR_LEN]; /**< remote BD */
+	T_GAP_ROLE              role;                   //!< Device role
+} T_APP_LINK;
+/** @} */
+/* End of group */
+/** @addtogroup  CENTRAL_CLIENT_SCAN_MGR
+	 * @brief  Device list block definition.
+	 */
+typedef struct {
+	uint8_t 	 bd_addr[GAP_BD_ADDR_LEN];	/**< remote BD */
+	uint8_t 	 bd_type;			   /**< remote BD type*/
+} T_DEV_INFO;
+
+typedef enum
+{
+	BT_MATTER_MSG_START_ADV = 12,
+	BT_MATTER_MSG_STOP_ADV,
+	BT_MATTER_MSG_SEND_DATA,
+} BT_MATTER_SERVER_MSG_TYPE;
+
+typedef enum
+{
+	BT_MATTER_SEND_CB_MSG_DISCONNECTED = 1,
+	BT_MATTER_SEND_CB_MSG_CONNECTED,
+	BT_MATTER_SEND_CB_MSG_SEND_DATA_COMPLETE,
+	BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE,
+	BT_MATTER_SEND_CB_MSG_IND_NTF_DISABLE,
+	BT_MATTER_SEND_CB_MSG_WRITE_CHAR,
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	BLE_MATTER_MSG_CONNECTED_MULTI_ADV,
+	BLE_MATTER_MSG_DISCONNECTED_MULTI_ADV,
+	BLE_MATTER_MSG_WRITE_CHAR_MULTI_ADV,
+	BLE_MATTER_MSG_CCCD_RECV_ENABLE_MULTI_ADV,
+	BLE_MATTER_MSG_CCCD_RECV_DISABLE_MULTI_ADV,
+	BLE_MATTER_MSG_SEND_DATA_COMPLETE_MULTI_ADV,
+#endif
+} BT_MATTER_SEND_MSG_TYPE;
+
+typedef enum
+{
+	CB_PROFILE_CALLBACK = 0x01,  /**< bt_matter_adapter_app_profile_callback */
+	CB_GAP_CALLBACK = 0x02, /**< bt_matter_adapter_app_gap_callback */
+	CB_GAP_MSG_CONN_EVENT = 0x3, /**< bt_matter_adapter_app_handle_gap_msg */
+} T_CHIP_BLEMGR_CALLBACK_TYPE;
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+typedef struct {
+	uint8_t 	 adv_datalen;
+	uint8_t 	 scanrsp_datalen;
+	uint8_t      adv_data[31];
+	uint8_t      scanrsp_data[31];
+	uint16_t 	 H_adv_intval;
+	uint8_t 	 local_bd_type;
+	uint8_t 	 is_used;
+	uint8_t 	 type;        //1 means matter   2 means customer
+	uint8_t 	 adv_id;
+	void 		*one_shot_timer;
+	void 		*update_adv_mutex;
+	uint16_t 	adv_int_min;
+	uint16_t 	adv_int_max;
+	bool		connect_flag;
+} M_MULTI_ADV_PARAM;
+
+typedef struct {
+	void *task_handle;
+	void *sem_handle;
+	void *queue_handle;
+	bool deinit_flag;
+	uint8_t customer_sta_sto_flag;   //for customer
+	uint8_t matter_sta_sto_flag;   //for matter
+	uint8_t adv_id;
+} T_MULTI_ADV_CONCURRENT;
+#endif
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+#if CONFIG_BLE_MATTER_MULTI_ADV
+uint8_t matter_get_unused_adv_index(void);
+
+bool matter_matter_ble_adv_stop_by_adv_id(uint8_t *adv_id);
+
+bool customer_matter_ble_adv_start_by_adv_id(uint8_t *adv_id, uint8_t *adv_data, uint16_t adv_len, uint8_t *rsp_data, uint16_t rsp_len, uint8_t type);
+
+uint8_t ble_matter_adapter_judge_adv_stop(uint8_t adv_id);
+
+void ble_matter_adapter_multi_adv_task_func(void *arg);
+
+void ble_matter_adapter_multi_adv_init();
+
+void ble_matter_adapter_multi_adv_deinit();
+
+void ble_matter_adapter_send_multi_adv_msg(uint8_t adv_id);
+
+void ble_matter_adapter_legacy_start_adv_callback(void *data);
+
+void ble_matter_adapter_delete_adv(uint8_t adv_id);
+#endif
+
+int ble_matter_adapter_app_handle_upstream_msg(uint16_t subtype, void *pdata);
+
+void ble_matter_adapter_app_handle_callback_msg(T_IO_MSG callback_msg);
+
+void ble_matter_adapter_app_handle_io_msg(T_IO_MSG io_msg);
+
+void ble_matter_adapter_app_handle_dev_state_evt(T_GAP_DEV_STATE new_state, uint16_t cause);
+
+void ble_matter_adapter_app_handle_conn_state_evt(uint8_t conn_id, T_GAP_CONN_STATE new_state, uint16_t disc_cause);
+
+void ble_matter_adapter_app_handle_authen_state_evt(uint8_t conn_id, uint8_t new_state, uint16_t cause);
+
+void ble_matter_adapter_app_handle_conn_mtu_info_evt(uint8_t conn_id, uint16_t mtu_size);
+
+void ble_matter_adapter_app_handle_conn_param_update_evt(uint8_t conn_id, uint8_t status, uint16_t cause);
+
+void ble_matter_adapter_app_handle_gap_msg(T_IO_MSG *p_gap_msg);
+
+void bt_matter_device_matter_app_parse_scan_info(T_LE_SCAN_INFO *scan_info);
+
+void ble_matter_adapter_gcs_handle_discovery_result(uint8_t conn_id, T_GCS_DISCOVERY_RESULT discov_result);
+
+/**
+ * @brief  Callback will be called when data sent from profile client layer.
+ * @param  client_id the ID distinguish which module sent the data.
+ * @param  conn_id connection ID.
+ * @param  p_data  pointer to data.
+ * @retval   result @ref T_APP_RESULT
+ */
+T_APP_RESULT ble_matter_adapter_gcs_client_callback(T_CLIENT_ID client_id, uint8_t conn_id, void *p_data);
+
+/**
+  * @brief Callback for gap le to notify app
+  * @param[in] cb_type callback msy type @ref GAP_LE_MSG_Types.
+  * @param[in] p_cb_data point to callback data @ref T_LE_CB_DATA.
+  * @retval result @ref T_APP_RESULT
+  */
+T_APP_RESULT ble_matter_adapter_app_gap_callback(uint8_t cb_type, void *p_cb_data);
+
+T_APP_RESULT ble_matter_adapter_app_client_callback(T_CLIENT_ID client_id, uint8_t conn_id, void *p_data);
+
+T_APP_RESULT ble_matter_adapter_app_profile_callback(T_SERVER_ID service_id, void *p_data);
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+void ble_matter_adapter_app_vendor_callback(uint8_t cb_type, void *p_cb_data);
+#endif
+
+#if F_BT_GAPS_CHAR_WRITEABLE
+T_APP_RESULT ble_matter_adapter_gap_service_callback(T_SERVER_ID service_id, void *p_para)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_flags.h
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_flags.h
@@ -1,0 +1,44 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      app_flags.h
+   * @brief     This file is used to config app functions.
+   * @author    jane
+   * @date      2017-06-06
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+#ifndef _BLE_MATTER_ADAPTER_APP_FLAGS_H_
+#define _BLE_MATTER_ADAPTER_APP_FLAGS_H_
+
+#include <bt_flags.h>
+#include <app_common_flags.h>
+
+/** @defgroup  CENTRAL_CLIENT_Config Central Client App Configuration
+    * @brief This file is used to config app functions.
+    * @{
+    */
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+/** @brief  Config APP LE link number */
+#if defined(CONFIG_PLATFORM_8721D)
+#define BLE_MATTER_ADAPTER_APP_MAX_LINKS  4
+#define BLE_MATTER_ADAPTER_PERIPHERAL_APP_MAX_LINKS   1 //for max slave link num
+#define BLE_MATTER_ADAPTER_CENTRAL_APP_MAX_LINKS      3 //for max master link num
+#elif defined(CONFIG_PLATFORM_8710C)
+#define BLE_MATTER_ADAPTER_APP_MAX_LINKS  2
+#define BLE_MATTER_ADAPTER_PERIPHERAL_APP_MAX_LINKS   1 //for max slave link num
+#define BLE_MATTER_ADAPTER_CENTRAL_APP_MAX_LINKS      1 //for max master link num
+#endif
+
+/** @brief  Config the discovery table number of gcs_client */
+#define BLE_MATTER_ADAPTER_APP_MAX_DISCOV_TABLE_NUM 40
+
+/** @} */ /* End of group CENTRAL_CLIENT_Config */
+
+#endif

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_main.c
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_main.c
@@ -1,0 +1,337 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      main.c
+   * @brief     Source file for BLE central client project, mainly used for initialize modules
+   * @author    jane
+   * @date      2017-06-12
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+
+/*============================================================================*
+ *                              Header Files
+ *============================================================================*/
+#include "platform_opts_bt.h"
+#if defined(CONFIG_BLE_MATTER_ADAPTER) && CONFIG_BLE_MATTER_ADAPTER
+#include <os_sched.h>
+#include <string.h>
+#include <trace_app.h>
+#include <gap.h>
+#include <gap_config.h>
+#include <gap_bond_le.h>
+#include <gap_scan.h>
+#include <profile_client.h>
+#include <gap_msg.h>
+#include <gcs_client.h>
+#include "trace_uart.h"
+#include <bte.h>
+#include "wifi_constants.h"
+#include <profile_server.h>
+#include <gap_adv.h>
+#include <gap_le_types.h>
+#include <simple_ble_config.h>
+#include <gatt_builtin_services.h>
+#include <wifi_conf.h>
+#include "rtk_coex.h"
+#include "matter_blemgr_common.h"
+#include <ble_matter_adapter_app.h>
+#include <ble_matter_adapter_app_task.h>
+#include <ble_matter_adapter_app_main.h>
+#if CONFIG_BLE_MATTER_MULTI_ADV
+#include "vendor_cmd_bt.h"
+#endif
+/** @defgroup  CENTRAL_CLIENT_DEMO_MAIN Central Client Main
+    * @brief Main file to initialize hardware and BT stack and start task scheduling
+    * @{
+    */
+
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+/** @brief Default scan interval (units of 0.625ms, 0x520=820ms) */
+#define DEFAULT_SCAN_INTERVAL     0x520
+/** @brief Default scan window (units of 0.625ms, 0x520=820ms) */
+#define DEFAULT_SCAN_WINDOW       0x520
+
+/** @brief  Default minimum advertising interval when device is discoverable (units of 625us, 160=100ms) */
+#define DEFAULT_ADVERTISING_INTERVAL_MIN            192 //120ms
+/** @brief  Default maximum advertising interval */
+#define DEFAULT_ADVERTISING_INTERVAL_MAX            192 //120ms
+
+extern T_SERVER_ID ble_matter_adapter_service_id;//from app.c
+extern T_GAP_DEV_STATE ble_matter_adapter_gap_dev_state;
+#if CONFIG_BLE_MATTER_MULTI_ADV
+extern uint8_t matter_local_static_random_addr[6];
+#endif
+
+typedef struct {
+	uint8_t 	 is_exist;
+	uint8_t 	 reserved;		   /**< remote BD type*/
+	uint8_t 	 bd_addr[GAP_BD_ADDR_LEN];	/**< remote BD */
+} T_APP_STATIC_RANDOM_ADDR;
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+/**
+ * @brief  Config bt stack related feature
+ *
+ * NOTE: This function shall be called before @ref bte_init is invoked.
+ * @return void
+ */
+#ifndef PLATFORM_OHOS
+void ble_matter_adapter_bt_stack_config_init(void)
+{
+	gap_config_max_le_link_num(BLE_MATTER_ADAPTER_APP_MAX_LINKS);
+	gap_config_max_le_paired_device(BLE_MATTER_ADAPTER_APP_MAX_LINKS);
+}
+#else
+extern void gap_config_deinit_flow(uint8_t deinit_flow);
+void ble_matter_adapter_bt_stack_config_init(void)
+{
+	gap_config_max_le_link_num(BLE_MATTER_ADAPTER_APP_MAX_LINKS);
+	gap_config_max_le_paired_device(BLE_MATTER_ADAPTER_APP_MAX_LINKS);
+	gap_config_deinit_flow(1);
+}
+#endif
+
+/**
+  * @brief  Initialize central and gap bond manager related parameters
+  * @return void
+  */
+void ble_matter_adapter_app_le_gap_init(void)
+{
+	/* Device name and device appearance */
+	uint8_t  device_name[GAP_DEVICE_NAME_LEN] = "BLE_MATTER_ADAPTER";
+	uint16_t appearance = GAP_GATT_APPEARANCE_UNKNOWN;
+
+	/* Advertising parameters */
+	uint8_t  adv_evt_type = GAP_ADTYPE_ADV_IND;
+	uint8_t  adv_direct_type = GAP_REMOTE_ADDR_LE_PUBLIC;
+	uint8_t  adv_direct_addr[GAP_BD_ADDR_LEN] = {0};
+	uint8_t  adv_chann_map = GAP_ADVCHAN_ALL;
+	uint8_t  adv_filter_policy = GAP_ADV_FILTER_ANY;
+	uint16_t adv_int_min = DEFAULT_ADVERTISING_INTERVAL_MIN;
+	uint16_t adv_int_max = DEFAULT_ADVERTISING_INTERVAL_MAX;
+
+	/* Scan parameters */
+	uint8_t  scan_mode = GAP_SCAN_MODE_ACTIVE;
+	uint16_t scan_interval = DEFAULT_SCAN_INTERVAL;
+	uint16_t scan_window = DEFAULT_SCAN_WINDOW;
+	uint8_t  scan_filter_policy = GAP_SCAN_FILTER_ANY;
+	uint8_t  scan_filter_duplicate = GAP_SCAN_FILTER_DUPLICATE_ENABLE;
+
+	/* GAP Bond Manager parameters */
+	uint8_t  auth_pair_mode = GAP_PAIRING_MODE_PAIRABLE;
+	uint16_t auth_flags = GAP_AUTHEN_BIT_BONDING_FLAG;
+	uint8_t  auth_io_cap = GAP_IO_CAP_NO_INPUT_NO_OUTPUT;
+#if F_BT_LE_SMP_OOB_SUPPORT
+	uint8_t  auth_oob = false;
+#endif
+	uint8_t  auth_use_fix_passkey = false;
+	uint32_t auth_fix_passkey = 0;
+	uint8_t  auth_sec_req_enable = false;
+	uint16_t auth_sec_req_flags = GAP_AUTHEN_BIT_BONDING_FLAG;
+
+	/* Set device name and device appearance */
+	le_set_gap_param(GAP_PARAM_DEVICE_NAME, GAP_DEVICE_NAME_LEN, device_name);
+	le_set_gap_param(GAP_PARAM_APPEARANCE, sizeof(appearance), &appearance);
+
+	/* Set advertising parameters */
+	le_adv_set_param(GAP_PARAM_ADV_EVENT_TYPE, sizeof(adv_evt_type), &adv_evt_type);
+	le_adv_set_param(GAP_PARAM_ADV_DIRECT_ADDR_TYPE, sizeof(adv_direct_type), &adv_direct_type);
+	le_adv_set_param(GAP_PARAM_ADV_DIRECT_ADDR, sizeof(adv_direct_addr), adv_direct_addr);
+	le_adv_set_param(GAP_PARAM_ADV_CHANNEL_MAP, sizeof(adv_chann_map), &adv_chann_map);
+	le_adv_set_param(GAP_PARAM_ADV_FILTER_POLICY, sizeof(adv_filter_policy), &adv_filter_policy);
+	le_adv_set_param(GAP_PARAM_ADV_INTERVAL_MIN, sizeof(adv_int_min), &adv_int_min);
+	le_adv_set_param(GAP_PARAM_ADV_INTERVAL_MAX, sizeof(adv_int_max), &adv_int_max);
+
+	/* Set scan parameters */
+	le_scan_set_param(GAP_PARAM_SCAN_MODE, sizeof(scan_mode), &scan_mode);
+	le_scan_set_param(GAP_PARAM_SCAN_INTERVAL, sizeof(scan_interval), &scan_interval);
+	le_scan_set_param(GAP_PARAM_SCAN_WINDOW, sizeof(scan_window), &scan_window);
+	le_scan_set_param(GAP_PARAM_SCAN_FILTER_POLICY, sizeof(scan_filter_policy),
+					  &scan_filter_policy);
+	le_scan_set_param(GAP_PARAM_SCAN_FILTER_DUPLICATES, sizeof(scan_filter_duplicate),
+					  &scan_filter_duplicate);
+
+	/* Setup the GAP Bond Manager */
+	gap_set_param(GAP_PARAM_BOND_PAIRING_MODE, sizeof(auth_pair_mode), &auth_pair_mode);
+	gap_set_param(GAP_PARAM_BOND_AUTHEN_REQUIREMENTS_FLAGS, sizeof(auth_flags), &auth_flags);
+	gap_set_param(GAP_PARAM_BOND_IO_CAPABILITIES, sizeof(auth_io_cap), &auth_io_cap);
+#if F_BT_LE_SMP_OOB_SUPPORT
+	gap_set_param(GAP_PARAM_BOND_OOB_ENABLED, sizeof(auth_oob), &auth_oob);
+#endif
+	le_bond_set_param(GAP_PARAM_BOND_FIXED_PASSKEY, sizeof(auth_fix_passkey), &auth_fix_passkey);
+	le_bond_set_param(GAP_PARAM_BOND_FIXED_PASSKEY_ENABLE, sizeof(auth_use_fix_passkey),
+					  &auth_use_fix_passkey);
+	le_bond_set_param(GAP_PARAM_BOND_SEC_REQ_ENABLE, sizeof(auth_sec_req_enable), &auth_sec_req_enable);
+	le_bond_set_param(GAP_PARAM_BOND_SEC_REQ_REQUIREMENT, sizeof(auth_sec_req_flags),
+					  &auth_sec_req_flags);
+
+	/* register gap message callback */
+	le_register_app_cb(ble_matter_adapter_app_gap_callback);
+
+#if F_BT_GAPS_CHAR_WRITEABLE
+	uint8_t appearance_prop = GAPS_PROPERTY_WRITE_ENABLE;
+	uint8_t device_name_prop = GAPS_PROPERTY_WRITE_ENABLE;
+	T_LOCAL_APPEARANCE appearance_local;
+	T_LOCAL_NAME local_device_name;
+	if (flash_load_local_appearance(&appearance_local) == 0) {
+		gaps_set_parameter(GAPS_PARAM_APPEARANCE, sizeof(uint16_t), &appearance_local.local_appearance);
+	}
+
+	if (flash_load_local_name(&local_device_name) == 0) {
+		gaps_set_parameter(GAPS_PARAM_DEVICE_NAME, GAP_DEVICE_NAME_LEN, local_device_name.local_name);
+	}
+	gaps_set_parameter(GAPS_PARAM_APPEARANCE_PROPERTY, sizeof(appearance_prop), &appearance_prop);
+	gaps_set_parameter(GAPS_PARAM_DEVICE_NAME_PROPERTY, sizeof(device_name_prop), &device_name_prop);
+	gatt_register_callback((void *)ble_matter_adapter_gap_service_callback);
+#endif
+	T_APP_STATIC_RANDOM_ADDR random_addr;
+	uint8_t local_bd_type = GAP_LOCAL_ADDR_LE_RANDOM;
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	bool gen_addr = true;
+	if (gen_addr)
+	{
+		if (le_gen_rand_addr(GAP_RAND_ADDR_STATIC, random_addr.bd_addr) == GAP_CAUSE_SUCCESS)
+		{
+			random_addr.is_exist = true;
+			//ble_matter_adapter_app_save_static_random_address(&random_addr);
+		}
+	}
+	printf("random_addr.bd_addr = 0x%02x:0x%02x:0x%02x:0x%02x:0x%02x:0x%02x\r\n", \
+		random_addr.bd_addr[5], random_addr.bd_addr[4], random_addr.bd_addr[3], random_addr.bd_addr[2], random_addr.bd_addr[1], random_addr.bd_addr[0]);
+	le_set_gap_param(GAP_PARAM_RANDOM_ADDR, 6, random_addr.bd_addr);
+
+	memcpy(matter_local_static_random_addr, random_addr.bd_addr, 6);
+#else
+	le_cfg_local_identity_address(random_addr.bd_addr, GAP_IDENT_ADDR_RAND);
+	le_adv_set_param(GAP_PARAM_ADV_LOCAL_ADDR_TYPE, sizeof(local_bd_type), &local_bd_type);
+#endif
+
+#if F_BT_LE_5_0_SET_PHY_SUPPORT
+	uint8_t phys_prefer = GAP_PHYS_PREFER_ALL;
+	uint8_t tx_phys_prefer = GAP_PHYS_PREFER_1M_BIT | GAP_PHYS_PREFER_2M_BIT;
+	uint8_t rx_phys_prefer = GAP_PHYS_PREFER_1M_BIT | GAP_PHYS_PREFER_2M_BIT;
+	le_set_gap_param(GAP_PARAM_DEFAULT_PHYS_PREFER, sizeof(phys_prefer), &phys_prefer);
+	le_set_gap_param(GAP_PARAM_DEFAULT_TX_PHYS_PREFER, sizeof(tx_phys_prefer), &tx_phys_prefer);
+	le_set_gap_param(GAP_PARAM_DEFAULT_RX_PHYS_PREFER, sizeof(rx_phys_prefer), &rx_phys_prefer);
+#endif
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	vendor_cmd_init(ble_matter_adapter_app_vendor_callback);
+#endif
+}
+
+/**
+ * @brief  Add GATT clients and register callbacks
+ * @return void
+ */	
+void ble_matter_adapter_app_le_profile_init(void)
+{
+	/* Register Server Callback */
+	server_init(1);
+
+#if CONFIG_BLE_MATTER_MULTI_ADV
+	ble_matter_adapter_service_id = ble_matter_adapter_service_add_service((void *)ble_matter_adapter_app_profile_callback);
+#else
+	ble_matter_adapter_service_id = ble_matter_adapter_service_add_service((void *)ble_matter_adapter_app_profile_callback);
+#endif
+	server_register_app_cb(ble_matter_adapter_app_profile_callback);
+	
+	/* Add Client Module */
+	client_init(1);
+	ble_matter_adapter_gcs_client_id = gcs_add_client(ble_matter_adapter_gcs_client_callback, BLE_MATTER_ADAPTER_APP_MAX_LINKS, BLE_MATTER_ADAPTER_APP_MAX_DISCOV_TABLE_NUM);
+	/* Register Client Callback--App_ClientCallback to handle events from Profile Client layer. */
+        client_register_general_client_cb(ble_matter_adapter_app_client_callback);
+}
+
+
+/**
+ * @brief    Contains the initialization of all tasks
+ * @note     There is only one task in BLE Central Client APP, thus only one APP task is init here
+ * @return   void
+ */
+void ble_matter_adapter_task_init(void)
+{
+	ble_matter_adapter_app_task_init();
+}
+
+/**
+ * @brief    Entry of APP code
+ * @return   int (To avoid compile warning)
+ */
+int ble_matter_adapter_app_main(void)
+{
+	bt_trace_init();
+	ble_matter_adapter_bt_stack_config_init();
+	bte_init();
+	le_gap_init(BLE_MATTER_ADAPTER_APP_MAX_LINKS);
+	ble_matter_adapter_app_le_gap_init();
+	ble_matter_adapter_app_le_profile_init();
+	ble_matter_adapter_task_init();
+
+	return 0;
+}
+
+int ble_matter_adapter_app_init(void)
+{
+	//(void) bt_stack_already_on;
+	T_GAP_DEV_STATE new_state;
+
+	/*Wait WIFI init complete*/
+	while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
+		os_delay(1000);
+	}
+	
+	//judge BLE central is already on
+	le_get_gap_param(GAP_PARAM_DEV_STATE, &new_state);
+	if (new_state.gap_init_state == GAP_INIT_STATE_STACK_READY) {
+		printf("[BLE Matter Adapter]BT Stack already on\n\r");
+		return 0;
+	} else {
+		ble_matter_adapter_app_main();
+	}
+
+	bt_coex_init();
+
+	/*Wait BT init complete*/
+	do {
+		os_delay(100);
+		le_get_gap_param(GAP_PARAM_DEV_STATE, &new_state);
+	} while (new_state.gap_init_state != GAP_INIT_STATE_STACK_READY);
+
+	return 0;
+
+}
+
+void ble_matter_adapter_app_deinit(void)
+{
+
+	T_GAP_DEV_STATE state;
+	ble_matter_adapter_app_task_deinit();
+	le_get_gap_param(GAP_PARAM_DEV_STATE, &state);
+	if (state.gap_init_state != GAP_INIT_STATE_STACK_READY) {
+		printf("[BLE Matter Adapter]BT Stack is not running\n\r");
+		ble_matter_adapter_gap_dev_state.gap_init_state = GAP_INIT_STATE_INIT;
+	}
+	
+#if F_BT_DEINIT
+	else {
+		gcs_delete_client();
+		bte_deinit();
+		bt_trace_uninit();
+		printf("[BLE Matter Adapter]BT Stack deinitalized\n\r");
+	}
+#endif
+	ble_matter_adapter_gap_dev_state.gap_init_state = GAP_INIT_STATE_INIT;
+}
+
+/** @} */ /* End of group CENTRAL_CLIENT_DEMO_MAIN */
+#endif
+

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_main.h
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_main.h
@@ -1,0 +1,59 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      bt_matter_adapter_peripheral_app.h
+   * @brief     This file handles BLE peripheral application routines.
+   * @author    jane
+   * @date      2017-06-06
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+#ifndef _BLE_MATTER_ADAPTER_APP_MAIN_H__
+#define _BLE_MATTER_ADAPTER_APP_MAIN_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*============================================================================*
+ *                              Header Files
+ *============================================================================*/
+#include <app_msg.h>
+#include <profile_server.h>
+
+/*============================================================================*
+ *                              Variables
+ *============================================================================*/
+
+
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+#ifndef PLATFORM_OHOS
+void ble_matter_adapter_bt_stack_config_init(void);
+#else
+void ble_matter_adapter_bt_stack_config_init(void);
+#endif
+
+void ble_matter_adapter_app_le_gap_init(void);
+
+void ble_matter_adapter_app_le_gap_init(void);
+
+void ble_matter_adapter_app_le_profile_init(void);
+
+void ble_matter_adapter_task_init(void);
+
+int ble_matter_adapter_app_main(void);
+
+int ble_matter_adapter_app_init(void);
+
+void ble_matter_adapter_app_deinit(void);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_task.c
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_task.c
@@ -1,0 +1,234 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      app_task.c
+   * @brief     Routines to create App task and handle events & messages
+   * @author    jane
+   * @date      2017-06-02
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+
+/*============================================================================*
+ *                              Header Files
+ *============================================================================*/
+#include <platform_opts_bt.h>
+#if defined(CONFIG_BLE_MATTER_ADAPTER) && CONFIG_BLE_MATTER_ADAPTER //to be fixed
+#include <os_msg.h>
+#include <os_task.h>
+#include <gap.h>
+#include <gap_le.h>
+#include <ble_matter_adapter_app_task.h>
+#include <app_msg.h>
+#include <ble_matter_adapter_app.h>
+#include <basic_types.h>
+#include <gap_msg.h>
+#include <os_sync.h>
+
+/** @defgroup  CENTRAL_CLIENT_APP_TASK Central Client App Task
+    * @brief This file handles the implementation of application task related functions.
+    *
+    * Create App task and handle events & messages
+    * @{
+    */
+/*============================================================================*
+ *                              Macros
+ *============================================================================*/
+#define BLE_MATTER_ADAPTER_APP_TASK_PRIORITY             4         //!< Task priorities
+#define BLE_MATTER_ADAPTER_APP_TASK_STACK_SIZE           256 * 6   //!<  Task stack size
+#define BLE_MATTER_ADAPTER_MAX_NUMBER_OF_GAP_MESSAGE     0x20      //!<  GAP message queue size
+#define BLE_MATTER_ADAPTER_MAX_NUMBER_OF_IO_MESSAGE      0x20      //!<  IO message queue size
+#define BLE_MATTER_ADAPTER_MAX_NUMBER_OF_EVENT_MESSAGE   (BLE_MATTER_ADAPTER_MAX_NUMBER_OF_GAP_MESSAGE + BLE_MATTER_ADAPTER_MAX_NUMBER_OF_IO_MESSAGE)    //!< Event message queue size
+//ble matter
+#define BLE_MATTER_ADAPTER_CALLBACK_TASK_PRIORITY        4         //!< Task priorities
+#define BLE_MATTER_ADAPTER_CALLBACK_TASK_STACK_SIZE      256 * 6   //!<  Task stack size
+#define BLE_MATTER_ADAPTER_MAX_NUMBER_OF_CALLBACK_MESSAGE               0x20      //!< Callback message queue size
+/*============================================================================*
+ *                              Variables
+ *============================================================================*/
+void *ble_matter_adapter_app_task_handle;   //!< APP Task handle
+void *ble_matter_adapter_evt_queue_handle;  //!< Event queue handle
+void *ble_matter_adapter_io_queue_handle;   //!< IO queue handle
+
+void *ble_matter_adapter_callback_task_handle = NULL;    //!< Callback task handle
+void *ble_matter_adapter_callback_queue_handle = NULL;   //!< Callback queue handle
+
+extern T_GAP_DEV_STATE ble_matter_adapter_gap_dev_state;
+extern int ble_matter_adapter_central_app_max_links;
+extern int ble_matter_adapter_peripheral_app_max_links;
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+bool ble_matter_adapter_app_send_api_msg(uint16_t sub_type, void *arg)
+{
+	T_IO_MSG io_msg;
+
+	uint8_t event = EVENT_IO_TO_APP;
+
+	io_msg.type = IO_MSG_TYPE_QDECODE;
+	io_msg.subtype = sub_type;
+	io_msg.u.buf = arg;
+
+	if (ble_matter_adapter_evt_queue_handle != NULL && ble_matter_adapter_io_queue_handle != NULL) {
+		if (os_msg_send(ble_matter_adapter_io_queue_handle, &io_msg, 0) == false) {
+			printf("[%s] send io queue fail! type = 0x%x\r\n", __FUNCTION__, io_msg.subtype);
+			return false;
+		} else if (os_msg_send(ble_matter_adapter_evt_queue_handle, &event, 0) == false) {
+			printf("[%s] send event queue fail! type = 0x%x\r\n", __FUNCTION__, io_msg.subtype);
+			return false;
+		}
+	} else {
+		printf("[%s] queue is empty! type = 0x%x\r\n", __FUNCTION__, io_msg.subtype);
+		return false;
+	}
+
+	return true;
+}
+
+bool ble_matter_adapter_send_callback_msg(uint16_t msg_type, uint8_t cb_type, void *arg)
+{
+	T_IO_MSG callback_msg;
+	callback_msg.type = msg_type;
+
+	if( (msg_type==BT_MATTER_SEND_CB_MSG_SEND_DATA_COMPLETE) || (msg_type==BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE) ||\
+		(msg_type==BT_MATTER_SEND_CB_MSG_IND_NTF_DISABLE) || (msg_type==BT_MATTER_SEND_CB_MSG_WRITE_CHAR) )
+	{
+		callback_msg.subtype = cb_type;
+	}
+
+	callback_msg.u.buf = arg;
+	if (ble_matter_adapter_callback_queue_handle != NULL) {
+		if (os_msg_send(ble_matter_adapter_callback_queue_handle, &callback_msg, 0) == false) {
+			printf("bt matter send msg fail: subtype 0x%x", callback_msg.type);
+			return false;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+void ble_matter_adapter_callback_main_task(void *p_param)
+{
+	(void)p_param;
+	T_IO_MSG callback_msg;
+	os_msg_queue_create(&ble_matter_adapter_callback_queue_handle, BLE_MATTER_ADAPTER_MAX_NUMBER_OF_CALLBACK_MESSAGE, sizeof(T_IO_MSG));
+
+	while (true)
+	{
+		if (os_msg_recv(ble_matter_adapter_callback_queue_handle, &callback_msg, 0xFFFFFFFF) == true)
+		{
+			ble_matter_adapter_app_handle_callback_msg(callback_msg);
+		}
+	}
+}
+/**
+ * @brief  Initialize App task
+ * @return void
+ */
+void ble_matter_adapter_app_task_init(void)
+{
+	os_task_create(&ble_matter_adapter_app_task_handle, "ble_matter_adapter_app", ble_matter_adapter_app_main_task, 0, BLE_MATTER_ADAPTER_APP_TASK_STACK_SIZE,
+				   BLE_MATTER_ADAPTER_APP_TASK_PRIORITY);
+	os_task_create(&ble_matter_adapter_callback_task_handle, "ble_matter_adapter_callback", ble_matter_adapter_callback_main_task, 0, BLE_MATTER_ADAPTER_CALLBACK_TASK_STACK_SIZE,
+				   BLE_MATTER_ADAPTER_CALLBACK_TASK_PRIORITY);
+}
+
+/**
+ * @brief        App task to handle events & messages
+ * @param[in]    p_param    Parameters sending to the task
+ * @return       void
+ */
+void ble_matter_adapter_app_main_task(void *p_param)
+{
+	(void) p_param;
+	uint8_t event;
+
+	os_msg_queue_create(&ble_matter_adapter_io_queue_handle, BLE_MATTER_ADAPTER_MAX_NUMBER_OF_IO_MESSAGE, sizeof(T_IO_MSG));
+	os_msg_queue_create(&ble_matter_adapter_evt_queue_handle, BLE_MATTER_ADAPTER_MAX_NUMBER_OF_EVENT_MESSAGE, sizeof(uint8_t));
+
+	gap_start_bt_stack(ble_matter_adapter_evt_queue_handle, ble_matter_adapter_io_queue_handle, BLE_MATTER_ADAPTER_MAX_NUMBER_OF_GAP_MESSAGE);
+
+	while (true) {
+		if (os_msg_recv(ble_matter_adapter_evt_queue_handle, &event, 0xFFFFFFFF) == true) {
+			if (event == EVENT_IO_TO_APP) {
+				T_IO_MSG io_msg;
+				if (os_msg_recv(ble_matter_adapter_io_queue_handle, &io_msg, 0) == true) {
+					ble_matter_adapter_app_handle_io_msg(io_msg);
+				}
+			} else {
+				gap_handle_msg(event);
+			}
+		}
+	}
+}
+
+void ble_matter_adapter_app_task_deinit(void)
+{
+#ifndef PLATFORM_OHOS
+	if (ble_matter_adapter_io_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_io_queue_handle);
+	}
+	if (ble_matter_adapter_evt_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_evt_queue_handle);
+	}
+	if (ble_matter_adapter_callback_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_callback_queue_handle);
+	}
+	if (ble_matter_adapter_app_task_handle) {
+		os_task_delete(ble_matter_adapter_app_task_handle);
+	}
+	if (ble_matter_adapter_callback_task_handle) {
+		os_task_delete(ble_matter_adapter_callback_task_handle);
+	}
+#else
+	if (ble_matter_adapter_app_task_handle) {
+		os_task_delete(ble_matter_adapter_app_task_handle);
+	}
+	if (ble_matter_adapter_callback_task_handle) {
+		os_task_delete(ble_matter_adapter_callback_task_handle);
+	}
+	if (ble_matter_adapter_io_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_io_queue_handle);
+	}
+	if (ble_matter_adapter_evt_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_evt_queue_handle);
+	}
+	if (ble_matter_adapter_callback_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_callback_queue_handle);
+	}
+#endif
+	ble_matter_adapter_io_queue_handle = NULL;
+	ble_matter_adapter_evt_queue_handle = NULL;
+	ble_matter_adapter_callback_queue_handle = NULL;
+	ble_matter_adapter_app_task_handle = NULL;
+	ble_matter_adapter_callback_task_handle = NULL;
+
+	ble_matter_adapter_gap_dev_state.gap_init_state = 0;
+	ble_matter_adapter_gap_dev_state.gap_adv_sub_state = 0;
+	ble_matter_adapter_gap_dev_state.gap_adv_state = 0;
+	ble_matter_adapter_gap_dev_state.gap_scan_state = 0;
+	ble_matter_adapter_gap_dev_state.gap_conn_state = 0;
+
+	ble_matter_adapter_central_app_max_links = 0;
+	ble_matter_adapter_peripheral_app_max_links = 0;
+
+	//bt matter
+	if (ble_matter_adapter_callback_task_handle) {
+		os_task_delete(ble_matter_adapter_callback_task_handle);
+	}
+	if (ble_matter_adapter_callback_queue_handle) {
+		os_msg_queue_delete(ble_matter_adapter_callback_queue_handle);
+	}
+
+}
+
+
+/** @} */ /* End of group CENTRAL_CLIENT_APP_TASK */
+#endif
+

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_task.h
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_task.h
@@ -1,0 +1,36 @@
+/**
+*****************************************************************************************
+*     Copyright(c) 2017, Realtek Semiconductor Corporation. All rights reserved.
+*****************************************************************************************
+   * @file      app_task.h
+   * @brief     Routines to create App task and handle events & messages
+   * @author    jane
+   * @date      2017-06-02
+   * @version   v1.0
+   **************************************************************************************
+   * @attention
+   * <h2><center>&copy; COPYRIGHT 2017 Realtek Semiconductor Corporation</center></h2>
+   **************************************************************************************
+  */
+#ifndef __BLE_MATTER_ADAPTER_APP_TASK_H_
+#define __BLE_MATTER_ADAPTER_APP_TASK_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Initialize App task
+ * @return void
+ */
+bool ble_matter_adapter_app_send_api_msg(uint16_t sub_type, void *arg);
+bool ble_matter_adapter_send_callback_msg(uint16_t msg_type, uint8_t cb_type, void *arg);
+void ble_matter_adapter_callback_main_task(void *p_param);
+void ble_matter_adapter_app_main_task(void *p_param);
+void ble_matter_adapter_app_task_init(void);
+void ble_matter_adapter_app_task_deinit(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_service.c
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_service.c
@@ -1,0 +1,290 @@
+#include <platform_opts_bt.h>
+#if defined(CONFIG_BLE_MATTER_ADAPTER) && CONFIG_BLE_MATTER_ADAPTER
+#include <gap.h>
+#include <os_mem.h>
+#include <profile_server.h>
+#include <string.h>
+#include "platform_stdlib.h"
+#include "os_sync.h"
+#include <trace_app.h>
+#include "ble_matter_adapter_service.h"
+
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+#define MATTER_UUID_RX		0x11, 0x9D, 0x9F, 0x42, 0x9C, 0x4F, 0x9F, 0x95, 0x59, 0x45, 0x3D, 0x26, 0xF5, 0x2E, 0xEE, 0x18
+#define MATTER_UUID_TX		0x12, 0x9D, 0x9F, 0x42, 0x9C, 0x4F, 0x9F, 0x95, 0x59, 0x45, 0x3D, 0x26, 0xF5, 0x2E, 0xEE, 0x18
+#define MATTER_UUID_C3		0x04, 0x8F, 0x21, 0x83, 0x8A, 0x74, 0x7D, 0xB8, 0xF2, 0x45, 0x72, 0x87, 0x38, 0x02, 0x63, 0x64
+
+#define BT_MATTER_ADAPTER_SERVICE_C3_INDEX 0x07
+
+extern T_SERVER_ID ble_matter_adapter_service_id;
+
+/**<  Function pointer used to send event to application from ble config wifi profile. Initiated in bt_matter_adapter_service_add_service. */
+static P_FUN_SERVER_GENERAL_CB ble_matter_adapter_service_cb = NULL;
+
+/**< @brief  profile/service definition.  */
+/**should changed according BT team **/
+T_ATTRIB_APPL ble_matter_adapter_service_tbl[] =
+{
+	/* <<Primary Service>>, .. */
+	{
+		(ATTRIB_FLAG_VALUE_INCL | ATTRIB_FLAG_LE), /* flags */
+		{ /* type_value */
+			LO_WORD(GATT_UUID_PRIMARY_SERVICE),
+			HI_WORD(GATT_UUID_PRIMARY_SERVICE),
+			LO_WORD(0xFFF6), /* service UUID */
+			HI_WORD(0xFFF6)
+		},
+		UUID_16BIT_SIZE, /* bValueLen */
+		NULL, /* p_value_context */
+		GATT_PERM_READ /* permissions */
+	},
+	/* <<Characteristic>> Data RX */
+	{
+		ATTRIB_FLAG_VALUE_INCL, /* flags */
+		{ /* type_value */
+			LO_WORD(GATT_UUID_CHARACTERISTIC),
+			HI_WORD(GATT_UUID_CHARACTERISTIC),
+			(GATT_CHAR_PROP_WRITE | GATT_CHAR_PROP_WRITE_NO_RSP) /* characteristic properties */
+			/* characteristic UUID not needed here, is UUID of next attrib. */
+		},
+		1, /* bValueLen */
+		NULL,
+		GATT_PERM_READ /* permissions */
+	},
+	{
+		ATTRIB_FLAG_VALUE_APPL | ATTRIB_FLAG_UUID_128BIT, /* flags */
+		{ /* type_value */
+			MATTER_UUID_RX
+		},
+		0, /* bValueLen */
+		NULL,
+		GATT_PERM_WRITE /* permissions */
+	},
+		/* <<Characteristic>> Data TX */
+	{
+		ATTRIB_FLAG_VALUE_INCL, /* flags */
+		{ /* type_value */
+			LO_WORD(GATT_UUID_CHARACTERISTIC),
+			HI_WORD(GATT_UUID_CHARACTERISTIC),
+		(GATT_CHAR_PROP_READ | GATT_CHAR_PROP_INDICATE) /* characteristic properties */
+		/* characteristic UUID not needed here, is UUID of next attrib. */
+		},
+		1, /* bValueLen */
+		NULL,
+		GATT_PERM_READ /* permissions */
+	},
+	{
+		ATTRIB_FLAG_VALUE_APPL | ATTRIB_FLAG_UUID_128BIT, /* flags */
+		{ /* type_value */
+			MATTER_UUID_TX
+		},
+		0, /* bValueLen */
+		NULL,
+		GATT_PERM_READ //GATT_PERM_NONE // permissions 
+	},
+	/* client characteristic configuration */
+	{
+		ATTRIB_FLAG_VALUE_INCL | ATTRIB_FLAG_CCCD_APPL, /* flags */
+		{ /* type_value */
+			LO_WORD(GATT_UUID_CHAR_CLIENT_CONFIG),
+			HI_WORD(GATT_UUID_CHAR_CLIENT_CONFIG),
+			/* NOTE: this value has an instantiation for each client, a write to */
+			/* this attribute does not modify this default value: */
+			LO_WORD(GATT_CLIENT_CHAR_CONFIG_DEFAULT), /* client char. config. bit field */
+			HI_WORD(GATT_CLIENT_CHAR_CONFIG_DEFAULT)
+		},
+		2, /* bValueLen */
+		NULL,
+		(GATT_PERM_READ | GATT_PERM_WRITE) /* permissions */
+	},
+
+	/* <<Characteristic>> C3 Data TX */
+	{
+		ATTRIB_FLAG_VALUE_INCL, /* flags */
+		{ /* type_value */
+			LO_WORD(GATT_UUID_CHARACTERISTIC),
+			HI_WORD(GATT_UUID_CHARACTERISTIC),
+			(GATT_CHAR_PROP_READ) /* characteristic properties */
+			/* characteristic UUID not needed here, is UUID of next attrib. */
+		},
+		1, /* bValueLen */
+		NULL,
+		GATT_PERM_READ /* permissions */
+	},
+	{
+		ATTRIB_FLAG_VALUE_APPL | ATTRIB_FLAG_UUID_128BIT, /* flags */
+		{ /* type_value */
+			MATTER_UUID_C3
+		},
+		0, /* bValueLen */
+		NULL,
+		GATT_PERM_READ //GATT_PERM_NONE // permissions
+	},
+};
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+/**
+ * @brief read characteristic data from service.
+ *
+ * @param service_id          ServiceID of characteristic data.
+ * @param attrib_index        Attribute index of getting characteristic data.
+ * @param offset              Used for Blob Read.
+ * @param p_length            length of getting characteristic data.
+ * @param pp_value            data got from service.
+ * @return Profile procedure result
+*/
+T_APP_RESULT  ble_matter_adapter_service_attr_read_cb(uint8_t conn_id, T_SERVER_ID service_id,
+                                            uint16_t attrib_index, uint16_t offset, uint16_t *p_length, uint8_t **pp_value)
+{
+    T_APP_RESULT  cause  = APP_RESULT_SUCCESS;
+    switch (attrib_index)
+    {
+    case BT_MATTER_ADAPTER_SERVICE_C3_INDEX:
+        {
+            T_MATTER_CALLBACK_DATA callback_data;
+            callback_data.msg_type = SERVICE_CALLBACK_TYPE_READ_CHAR_VALUE;
+            callback_data.conn_id = conn_id;
+            if (ble_matter_adapter_service_cb)
+            {
+                ble_matter_adapter_service_cb(service_id, (void *)&callback_data);
+            }
+            *pp_value = callback_data.msg_data.write_read.p_value;
+            *p_length = callback_data.msg_data.write_read.len;
+        }
+        break;
+    default:
+        printf("bt_matter_adapter_service_attr_read_cb, Attr not found, index %d", attrib_index);
+        cause = APP_RESULT_ATTR_NOT_FOUND;
+        break;
+    }
+
+    return (cause);
+}
+
+/**
+ * @brief write characteristic data from service.
+ *
+ * @param conn_id
+ * @param service_id        ServiceID to be written.
+ * @param attrib_index      Attribute index of characteristic.
+ * @param length            length of value to be written.
+ * @param p_value           value to be written.
+ * @return Profile procedure result
+*/
+T_APP_RESULT ble_matter_adapter_service_attr_write_cb(uint8_t conn_id, T_SERVER_ID service_id,
+                                            uint16_t attrib_index, T_WRITE_TYPE write_type, uint16_t length, uint8_t *p_value,
+                                            P_FUN_WRITE_IND_POST_PROC *p_write_ind_post_proc)
+{
+    T_MATTER_CALLBACK_DATA callback_data;
+    T_APP_RESULT  cause = APP_RESULT_SUCCESS;
+    APP_PRINT_INFO1("bt_matter_adapter_service_attr_write_cb write_type = 0x%x", write_type);
+    *p_write_ind_post_proc = NULL;
+
+    if (BT_MATTER_ADAPTER_SERVICE_CHAR_RX_INDEX == attrib_index) {
+        /* Make sure written value size is valid. */
+        if (p_value == NULL) {
+            cause  = APP_RESULT_INVALID_VALUE_SIZE;
+        } else {
+            /* Notify Application. */
+            callback_data.msg_type = SERVICE_CALLBACK_TYPE_WRITE_CHAR_VALUE;
+            callback_data.conn_id  = conn_id;
+            callback_data.msg_data.write_read.len = length;
+            callback_data.msg_data.write_read.p_value = p_value;
+
+            //handle_bt_matter_adapter_app_data(p_value, length);
+            if (ble_matter_adapter_service_cb) {
+                ble_matter_adapter_service_cb(service_id, (void *)&callback_data);
+            }
+        }
+    } else {
+            APP_PRINT_ERROR2("bt_matter_adapter_service_attr_write_cb Error: attrib_index 0x%x, length %d",
+                attrib_index, length);
+            cause = APP_RESULT_ATTR_NOT_FOUND;
+    }
+
+    return cause;
+}
+
+/**
+ * @brief update CCCD bits from stack.
+ *
+ * @param conn_id           connection id.
+ * @param service_id          Service ID.
+ * @param index          Attribute index of characteristic data.
+ * @param cccbits         CCCD bits from stack.
+ * @return None
+*/
+void ble_matter_adapter_service_cccd_update_cb(uint8_t conn_id, T_SERVER_ID service_id, uint16_t index,
+                                     uint16_t cccbits)
+{
+    T_MATTER_CALLBACK_DATA callback_data;
+    bool is_handled = false;
+    callback_data.conn_id = conn_id;
+    callback_data.msg_type = SERVICE_CALLBACK_TYPE_INDIFICATION_NOTIFICATION;
+    switch (index)
+    {
+    case BT_MATTER_ADAPTER_SERVICE_CHAR_INDICATE_CCCD_INDEX:
+        {
+            if (cccbits & GATT_CLIENT_CHAR_CONFIG_INDICATE)
+            {
+                // Enable Notification
+                callback_data.msg_data.notification_indification_index = MATTER_NOTIFY_INDICATE_V3_ENABLE;
+            }
+            else
+            {
+                // Disable Notification
+                callback_data.msg_data.notification_indification_index = MATTER_NOTIFY_INDICATE_V3_DISABLE;
+            }
+            is_handled =  true;
+        }
+        break;
+    default:
+        break;
+    }
+    /* Notify Application. */
+    if (ble_matter_adapter_service_cb && (is_handled == true))
+    {
+        ble_matter_adapter_service_cb(service_id, (void *)&callback_data);
+    }
+}
+
+/**
+ * @brief Simple ble Service Callbacks.
+*/
+const T_FUN_GATT_SERVICE_CBS ble_matter_adapter_service_cbs =
+{
+    ble_matter_adapter_service_attr_read_cb,  // Read callback function pointer
+    ble_matter_adapter_service_attr_write_cb, // Write callback function pointer
+    ble_matter_adapter_service_cccd_update_cb // CCCD update callback function pointer
+};
+
+
+
+/**
+  * @brief Add simple BLE service to the BLE stack database.
+  *
+  * @param[in]   p_func  Callback when service attribute was read, write or cccd update.
+  * @return Service id generated by the BLE stack: @ref T_SERVER_ID.
+  * @retval 0xFF Operation failure.
+  * @retval others Service id assigned by stack.
+  *
+  */
+T_SERVER_ID ble_matter_adapter_service_add_service(void *p_func)
+{
+    if (false == server_add_service(&ble_matter_adapter_service_id,
+                                    (uint8_t *)ble_matter_adapter_service_tbl,
+                                    sizeof(ble_matter_adapter_service_tbl),
+                                    ble_matter_adapter_service_cbs))
+    {
+        APP_PRINT_ERROR0("ble_matter_adapter_service_add_service: fail");
+        ble_matter_adapter_service_id = 0xff;
+        return ble_matter_adapter_service_id;
+    }
+
+    ble_matter_adapter_service_cb = (P_FUN_SERVER_GENERAL_CB)p_func;
+    return ble_matter_adapter_service_id;
+}
+#endif

--- a/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_service.h
+++ b/component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_service.h
@@ -1,0 +1,70 @@
+/* Define to prevent recursive inclusion */
+#ifndef _BLE_MATTER_ADAPTER_SERVICE_H_
+#define _BLE_MATTER_ADAPTER_SERVICE_H_
+
+#ifdef __cplusplus
+extern "C"  {
+#endif      /* __cplusplus */
+
+#include <profile_server.h>
+#include "platform_opts_bt.h"
+/*============================================================================*
+ *                              Constants
+ *============================================================================*/
+#define MATTER_NOTIFY_INDICATE_V3_ENABLE     1
+#define MATTER_NOTIFY_INDICATE_V3_DISABLE    2
+//#define SIMP_NOTIFY_INDICATE_V4_ENABLE     3
+//#define SIMP_NOTIFY_INDICATE_V4_DISABLE    4
+
+#define BT_MATTER_ADAPTER_SERVICE_CHAR_RX_INDEX                 0x02
+#define BT_MATTER_ADAPTER_SERVICE_CHAR_TX_INDEX                 0x04
+#define BT_MATTER_ADAPTER_SERVICE_CHAR_INDICATE_CCCD_INDEX      (BT_MATTER_ADAPTER_SERVICE_CHAR_TX_INDEX + 1)
+#define BT_MATTER_ADAPTER_SERVICE_C3_INDEX                      0x07
+
+typedef struct
+{
+    uint16_t len;
+    uint8_t *p_value;
+} T_MATTER_WRITE_READ_MSG;
+/** @} End of TSIMP_WRITE_MSG */
+
+/** @defgroup TSIMP_UPSTREAM_MSG_DATA TSIMP_UPSTREAM_MSG_DATA
+  * @brief Simple BLE service callback message content.
+  * @{
+  */
+typedef union
+{
+    uint8_t notification_indification_index; //!< ref: @ref SIMP_Service_Notify_Indicate_Info
+    T_MATTER_WRITE_READ_MSG write_read;
+} T_MATTER_UPSTREAM_MSG_DATA;
+
+/** @defgroup TSIMP_CALLBACK_DATA TSIMP_CALLBACK_DATA
+  * @brief Simple BLE service data to inform application.
+  * @{
+  */
+typedef struct
+{
+    uint8_t                 conn_id;
+    T_SERVICE_CALLBACK_TYPE msg_type;
+    T_MATTER_UPSTREAM_MSG_DATA msg_data;
+} T_MATTER_CALLBACK_DATA;
+/*============================================================================*
+ *                              Functions
+ *============================================================================*/
+T_APP_RESULT  ble_matter_adapter_service_attr_read_cb(uint8_t conn_id, T_SERVER_ID service_id,
+                                            uint16_t attrib_index, uint16_t offset, uint16_t *p_length, uint8_t **pp_value);
+                                            
+T_APP_RESULT ble_matter_adapter_service_attr_write_cb(uint8_t conn_id, T_SERVER_ID service_id,
+                                            uint16_t attrib_index, T_WRITE_TYPE write_type, uint16_t length, uint8_t *p_value,
+                                            P_FUN_WRITE_IND_POST_PROC *p_write_ind_post_proc); 
+                                                       
+void ble_matter_adapter_service_cccd_update_cb(uint8_t conn_id, T_SERVER_ID service_id, uint16_t index,
+                                     uint16_t cccbits);      
+                                                               
+T_SERVER_ID ble_matter_adapter_service_add_service(void *p_func);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BT_MATTER_ADAPTER_WIFI_SERVICE_H_ */

--- a/component/common/bluetooth/realtek/sdk/example/bt_mesh_multiple_profile/bt_mesh_device_matter/bt_mesh_device_matter_app_task.c
+++ b/component/common/bluetooth/realtek/sdk/example/bt_mesh_multiple_profile/bt_mesh_device_matter/bt_mesh_device_matter_app_task.c
@@ -107,6 +107,7 @@ bool bt_mesh_device_matter_adapter_send_callback_msg(uint16_t msg_type, uint8_t 
 {
 	T_IO_MSG callback_msg;
 	callback_msg.type = msg_type;
+	callback_msg.u.buf = arg;
 
 	if( (msg_type==BT_MATTER_SEND_CB_MSG_SEND_DATA_COMPLETE) || (msg_type==BT_MATTER_SEND_CB_MSG_IND_NTF_ENABLE) ||\
 		(msg_type==BT_MATTER_SEND_CB_MSG_IND_NTF_DISABLE) || (msg_type==BT_MATTER_SEND_CB_MSG_WRITE_CHAR) )
@@ -114,7 +115,6 @@ bool bt_mesh_device_matter_adapter_send_callback_msg(uint16_t msg_type, uint8_t 
 		callback_msg.subtype = cb_type;
 	}
 
-	callback_msg.u.buf = arg;
 	if (bt_mesh_device_matter_callback_queue_handle != NULL) {
 		if (os_msg_send(bt_mesh_device_matter_callback_queue_handle, &callback_msg, 0) == false) {
 			printf("bt matter send msg fail: subtype 0x%x", callback_msg.type);

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
@@ -59,7 +59,7 @@ ROMIMG =
 #BT_MATTER_MESH_ADAPTER = 1
 
 # Uncomment to enable multiple BLE with matter
-BLE_MATTER_ADAPTER = 1
+#BLE_MATTER_ADAPTER = 1
 
 # Include folder list
 # -------------------------------------------------------------------

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
@@ -58,6 +58,9 @@ ROMIMG =
 # Uncomment to enable BLE mesh with matter
 #BT_MATTER_MESH_ADAPTER = 1
 
+# Uncomment to enable multiple BLE with matter
+BLE_MATTER_ADAPTER = 1
+
 # Include folder list
 # -------------------------------------------------------------------
 
@@ -176,13 +179,18 @@ INCLUDES += -I../../../component/os/os_dep/include
 INCLUDES += -I../../../component/common/application/amazon/amazon-ffs/ffs_demo/common/include
 INCLUDES += -I../../../component/common/application/amazon/amazon-ffs/ffs_demo/realtek/configs
 
+
 # Matter
 ifdef BT_MATTER_MESH_ADAPTER
+INCLUDES += -I../../../component/common/application/matter/common/bluetooth/
 INCLUDES += -I../../../component/common/bluetooth/realtek/sdk/example/bt_mesh_multiple_profile/bt_mesh_device_matter
+else if BLE_MATTER_ADAPTER
+INCLUDES += -I../../../component/common/application/matter/common/bluetooth/
+INCLUDES += -I../../../component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/
 else
 INCLUDES += -I../../../component/common/application/matter/common/bluetooth/bt_matter_adapter
 endif
-INCLUDES += -I../../../component/common/application/matter/common/bluetooth
+
 INCLUDES += -I../../../component/common/application/matter/common/port
 INCLUDES += -I../../../component/common/application/matter/common/mbedtls
 INCLUDES += -I../../../component/common/application/matter/common/protobuf
@@ -304,12 +312,24 @@ SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_mesh_multipl
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_mesh_multiple_profile/bt_mesh_device_matter/bt_mesh_device_matter_app_task.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_mesh_multiple_profile/bt_mesh_device_matter/bt_mesh_device_matter_cmd.c
 else
+
+ifdef BLE_MATTER_ADAPTER
+SRC_C += ../../../component/common/application/matter/common/bluetooth/matter_blemgr_common.c
+
+#bluetooth - example - ble_matter_adapter
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_service.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_task.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app_main.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_matter_adapter/ble_matter_adapter_app.c
+
+else
 #bluetooth - example - bt_matter_adapter
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_app_main.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_app_task.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_peripheral_app.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_service.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_wifi.c
+endif
 endif
 
 #bluetooth - example
@@ -363,6 +383,7 @@ SRC_C += ../../../component/common/api/network/src/wlan_network.c
 SRC_C += ../../../component/common/utilities/cJSON.c
 SRC_C += ../../../component/common/utilities/http_client.c
 SRC_C += ../../../component/common/utilities/xml.c
+SRC_C += ../../../component/common/utilities/gb2unicode.c
 
 #matter - app
 SRC_C += ../../../component/common/application/matter/common/port/matter_dcts.c
@@ -722,6 +743,11 @@ endif
 # for matter mesh
 ifdef BT_MATTER_MESH_ADAPTER
 CFLAGS += -DCONFIG_BT_MESH_WITH_MATTER=1
+endif
+
+# for matter adapter
+ifdef BLE_MATTER_ADAPTER
+CFLAGS += -DCONFIG_BLE_MATTER_ADAPTER=1
 endif
 
 CFLAGS += -DCHIP_PROJECT=0

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -144,7 +144,7 @@ INCLUDES += -I$(BASEDIR)/../../../component/os/freertos/freertos_v10.0.1/Source/
 INCLUDES += -I$(BASEDIR)/../../../component/os/freertos/freertos_v10.0.1/Source/portable/GCC/ARM_RTL8710C
 INCLUDES += -I$(BASEDIR)/../../../component/os/os_dep/include
 
-INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth/
+INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth/bt_matter_adapter
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/mbedtls
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/port
@@ -181,7 +181,7 @@ CFLAGS += -DCONFIG_SYSTEM_TIME64=0
 endif
 
 # for matter blemgr adapter
-CFLAGS += -DCONFIG_MATTER_BLEMGR_ADAPTER=1
+#CFLAGS += -DCONFIG_MATTER_BLEMGR_ADAPTER=1
 
 # CHIP options
 # -------------------------------------------------------------------

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -144,7 +144,7 @@ INCLUDES += -I$(BASEDIR)/../../../component/os/freertos/freertos_v10.0.1/Source/
 INCLUDES += -I$(BASEDIR)/../../../component/os/freertos/freertos_v10.0.1/Source/portable/GCC/ARM_RTL8710C
 INCLUDES += -I$(BASEDIR)/../../../component/os/os_dep/include
 
-INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth
+INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth/
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/bluetooth/bt_matter_adapter
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/mbedtls
 INCLUDES += -I$(BASEDIR)/../../../component/common/application/matter/common/port
@@ -181,7 +181,7 @@ CFLAGS += -DCONFIG_SYSTEM_TIME64=0
 endif
 
 # for matter blemgr adapter
-#CFLAGS += -DCONFIG_MATTER_BLEMGR_ADAPTER=1
+CFLAGS += -DCONFIG_MATTER_BLEMGR_ADAPTER=1
 
 # CHIP options
 # -------------------------------------------------------------------

--- a/project/realtek_amebaz2_v0_example/inc/platform_opts_bt.h
+++ b/project/realtek_amebaz2_v0_example/inc/platform_opts_bt.h
@@ -38,13 +38,18 @@
 
 #ifdef CHIP_PROJECT
 /* For Matter Application */
-#ifdef CONFIG_BT_MESH_WITH_MATTER // this is toggled in application.is.matter.mk
+#ifdef CONFIG_BT_MESH_WITH_MATTER // this is defined in application.is.matter.mk
 #undef CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE
 #undef CONFIG_BT_MESH_DEVICE_MATTER
 #define CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE			1
-#define CONFIG_BT_MESH_DEVICE_MATTER					1
+#define CONFIG_BT_MESH_DEVICE_MATTER				1
+
+#elif CONFIG_BLE_MATTER_ADAPTER // this is defined in application.is.matter.mk
+#undef CONFIG_BLE_MATTER_MULTI_ADV
+#define CONFIG_BLE_MATTER_MULTI_ADV				1
+
 #else
-#define CONFIG_BT_MATTER_ADAPTER						1
+#define CONFIG_BT_MATTER_ADAPTER				1
 #endif
 
 /* For Matter Mesh Application */
@@ -53,8 +58,8 @@
 #error "Please enable both CONFIG_BT_MESH_DEVICE_MATTER & CONFIG_BT_MESH_DEVICE_MULTIPLE_PROFILE"
 #endif
 
-#if (!CONFIG_BT_MATTER_ADAPTER && !CONFIG_BT_MESH_DEVICE_MATTER)
-#error "Please enable either CONFIG_BT_MATTER_ADAPTER or CONFIG_BT_MESH_DEVICE_MATTER"
+#if (!CONFIG_BT_MATTER_ADAPTER && !CONFIG_BLE_MATTER_ADAPTER && !CONFIG_BT_MESH_DEVICE_MATTER)
+#error "Please enable either CONFIG_BT_MATTER_ADAPTER or CONFIG_BLE_MATTER_ADAPTER or CONFIG_BT_MESH_DEVICE_MATTER"
 #endif
 #endif
 #endif // CONFIG_BT


### PR DESCRIPTION
- Add ble_matter_adapter that uses one shot adv to support multiple adv ability.
- To enable ble_matter_adapter with multiple adv function:
Enable CONFIG_MATTER_BLEMGR_ADAPTER in lib_chip.mk
Enable BLE_MATTER_ADAPTER in application.is.matter.mk

** To support 2 ble slave connection feature, needs to update bt_normal_patch.c based on customer specific needs.