### PR TITLE
[portinglayer] fix tasks hogging the cpu

### DIFF
--- a/component/common/application/matter/core/matter_interaction.cpp
+++ b/component/common/application/matter/core/matter_interaction.cpp
@@ -55,7 +55,7 @@ void DownlinkTask(void * pvParameter)
     // Loop here and keep listening on the queue for Downlink (Firmware application to matter)
     while (true)
     {
-        BaseType_t eventReceived = xQueueReceive(DownlinkEventQueue, &event, pdMS_TO_TICKS(10));
+        BaseType_t eventReceived = xQueueReceive(DownlinkEventQueue, &event, portMAX_DELAY);
         while (eventReceived == pdTRUE)
         {
             DispatchDownlinkEvent(&event);
@@ -117,7 +117,7 @@ void UplinkTask(void * pvParameter)
     // Loop here and keep listening on the queue for Uplink (matter to Firmware application)
     while (true)
     {
-        BaseType_t eventReceived = xQueueReceive(UplinkEventQueue, &event, pdMS_TO_TICKS(10));
+        BaseType_t eventReceived = xQueueReceive(UplinkEventQueue, &event, portMAX_DELAY);
         while (eventReceived == pdTRUE)
         {
             DispatchUplinkEvent(&event);

--- a/component/common/application/matter/example/light/example_matter_light.cpp
+++ b/component/common/application/matter/example/light/example_matter_light.cpp
@@ -47,7 +47,7 @@ static void example_matter_light_task(void *pvParameters)
     if (err != CHIP_NO_ERROR)
         ChipLogProgress(DeviceLayer, "matter_interaction_start_uplink failed!\n");
 
-    while(1);
+    vTaskDelete(NULL);
 }
 
 extern "C" void example_matter_light(void)

--- a/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
+++ b/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
@@ -47,7 +47,7 @@ static void example_matter_thermostat_task(void *pvParameters)
     if (err != CHIP_NO_ERROR)
         ChipLogProgress(DeviceLayer, "matter_interaction_start_uplink failed!\n");
 
-    while(1);
+    vTaskDelete(NULL);
 }
 
 extern "C" void example_matter_thermostat(void)


### PR DESCRIPTION
- fix #123 
- the `example_matter_xxx_task` is only for starting up the matter related tasks, once it has done its job, we need to delete it, else the idle task cannot run and do cleanup
- in `uplink` and `downlink` tasks, let them block while waiting for event to arrive on the queue