### PR TITLE
[SDK] fix softap start fail

### DIFF
--- a/component/common/api/at_cmd/atcmd_wifi.c
+++ b/component/common/api/at_cmd/atcmd_wifi.c
@@ -810,7 +810,7 @@ void fATW4(void *arg){
         ret = RTW_BADARG;
         goto exit;
     }
-    memset((char *)ap.ssid.val, '\0', sizeof(ap.ssid.val));
+    memset((char *)password, '\0', sizeof(password));
     strncpy((char *)password, (char*)arg, sizeof(password) - 1);
     ap.password = password;
     ap.password_len = strlen((char*)arg);


### PR DESCRIPTION
* Fix softap unable to start in WEP/WPA/WPA2/WPA3 and others that sets password
* Synchronize with https://github.com/ambiot/ambz2_sdk/commit/84f29db3db1da3b834197d0c12212ac9aef42e7b