### PR TITLE
[build] update build to use gnu++17

### DIFF
--- a/component/common/application/matter/example/aircon/lib_chip_aircon_core.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_core.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
@@ -301,8 +301,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 # Compile

--- a/component/common/application/matter/example/light/lib_chip_light_core.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_core.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -301,8 +301,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 # Compile

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_core.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_core.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -302,8 +302,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 # Compile

--- a/component/soc/realtek/8710c/cmsis/rtl8710c/include/core_tm9_cache.h
+++ b/component/soc/realtek/8710c/cmsis/rtl8710c/include/core_tm9_cache.h
@@ -193,9 +193,9 @@ __STATIC_INLINE void SCB_NS_EnableDCache (void)
 __STATIC_INLINE void SCB_DisableDCache (void)
 {
   #if defined (__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    register uint32_t ccsidr;
-    register uint32_t sets;
-    register uint32_t ways;
+    uint32_t ccsidr;
+    uint32_t sets;
+    uint32_t ways;
 
     SCB->CSSELR = 0U; /*(0U << 1U) | 0U;*/  /* Level 1 data cache */
     __DSB();

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-deprecated-declarations
 CXXFLAGS += -Wno-unused-parameter
 CXXFLAGS += -Wno-format
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_core.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++11
-CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -295,8 +295,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-#CPPFLAGS += -std=gnu++11
-CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 include toolchain.mk

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_core.mk
@@ -217,8 +217,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -296,8 +296,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 include toolchain.mk

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -307,8 +307,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 include toolchain.mk

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_core.mk
@@ -220,8 +220,7 @@ CXXFLAGS += -Wno-format
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 
 CHIP_CFLAGS = $(CFLAGS)

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -298,8 +298,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 include toolchain.mk

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_core.mk
@@ -215,8 +215,7 @@ CXXFLAGS += -Wno-deprecated-declarations
 CXXFLAGS += -Wno-unused-parameter
 CXXFLAGS += -Wno-format
 
-CXXFLAGS += -std=gnu++14
-#CXXFLAGS += -std=c++14
+CXXFLAGS += -std=gnu++17
 CXXFLAGS += -fno-rtti
 CXXFLAGS += -Wno-format-nonliteral
 CXXFLAGS += -Wno-format-security

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -301,8 +301,7 @@ CPPFLAGS += -Wno-deprecated-declarations
 CPPFLAGS += -Wno-unused-parameter
 CPPFLAGS += -Wno-format
 
-CPPFLAGS += -std=gnu++14
-#CPPFLAGS += -std=c++14
+CPPFLAGS += -std=gnu++17
 CPPFLAGS += -fno-rtti
 
 include toolchain.mk


### PR DESCRIPTION
- matter sdk update requires to use C++17
- remove old `register` keywords
- remove `error-mapping` from build