### PR TITLE
[tools] set certification-type to 1 as default

### DIFF
--- a/tools/matter/factorydata/gen-certs.sh
+++ b/tools/matter/factorydata/gen-certs.sh
@@ -60,7 +60,7 @@ certificate_id="ZIG20142ZB330003-24"
 security_level=0
 security_info=0
 version_num=0x2694
-certification_type=0
+certification_type=1
 # dac_origin_vendor_id=1316
 # dac_origin_product_id=1A01
 


### PR DESCRIPTION
- Certification-type = 0 may result in failed case in SVE
- Set it to 1 on default