### PR TITLE
[ble-wifi] update factory reset to disconnect wifi and reset the board

### DIFF
--- a/component/common/application/matter/common/atcmd/atcmd_matter.c
+++ b/component/common/application/matter/common/atcmd/atcmd_matter.c
@@ -34,6 +34,8 @@ void fATchipapp(void *arg)
 	printf("Erased Fast Connect data\r\n");
 #endif
 	AT_PRINTK("[ATS#]: _AT_SYSTEM_TEST_");
+	wifi_disconnect();
+	sys_reset();
 }
 
 void fATchipapp1(void *arg)

--- a/component/common/application/matter/common/atcmd/atcmd_matter.c
+++ b/component/common/application/matter/common/atcmd/atcmd_matter.c
@@ -33,7 +33,7 @@ void fATchipapp(void *arg)
 	Erase_Fastconnect_data();
 	printf("Erased Fast Connect data\r\n");
 #endif
-	AT_PRINTK("[ATS#]: _AT_SYSTEM_TEST_");
+	AT_PRINTK("[ATM$]: _AT_SYSTEM_TEST_");
 	wifi_disconnect();
 	sys_reset();
 }


### PR DESCRIPTION
Fix #69 and Fix #128 
- added wifi_disconnect() to disconnect from the current connected wifi.
- added sys_reset() to directly reboot the board after factory reset.