### PR TITLE
[sdk] fix several issues

### DIFF
--- a/component/common/api/at_cmd/atcmd_lwip.c
+++ b/component/common/api/at_cmd/atcmd_lwip.c
@@ -4130,7 +4130,11 @@ static void client_start(void *param)
 				#endif
 				#if LWIP_IGMP
 				ip_addr_t dst_addr;
+#if LWIP_VERSION_MAJOR >= 2
+				ip_addr_set_ip4_u32(&dst_addr, c_serv_addr.sin_addr.s_addr);
+#else
 				dst_addr.addr = c_serv_addr.sin_addr.s_addr;
+#endif
 				if(ip_addr_ismulticast(&dst_addr)){
 					struct ip_mreq imr;
 					struct in_addr intfAddr;
@@ -4725,11 +4729,19 @@ void fATPB(void *arg)
 	}
 	if(enable){
 		if(argv[2] != NULL){
+#if LWIP_VERSION_MAJOR >= 2
+			ip_addr_set_ip4_u32(&dnsserver, ipaddr_addr(argv[2]));
+#else
 			ip4_addr_set_u32(&dnsserver, ipaddr_addr(argv[2]));
+#endif
 			dns_setserver(0,&dnsserver);			
 		}
 		else{
+#if LWIP_VERSION_MAJOR >= 2
+			ip_addr_set_ip4_u32(&dnsserver, ipaddr_addr("208.67.222.222"));
+#else
 			ip4_addr_set_u32(&dnsserver, ipaddr_addr("208.67.222.222"));
+#endif
 			dns_setserver(0, &dnsserver);
 			}
 		}
@@ -4740,7 +4752,11 @@ void fATPB(void *arg)
 			goto exit;
 			}
 		else{
+#if LWIP_VERSION_MAJOR >= 2
+			ip_addr_set_ip4_u32(&dnsserver, ipaddr_addr("208.67.222.222"));
+#else
 			ip4_addr_set_u32(&dnsserver, ipaddr_addr("208.67.222.222"));
+#endif
 			dns_setserver(0, &dnsserver);			
 		}
 	}
@@ -6972,7 +6988,11 @@ int atcmd_lwip_auto_connect(void)
 #endif
 #if LWIP_IGMP
 				ip_addr_t dst_addr;
+#if LWIP_VERSION_MAJOR >= 2
+				ip_addr_set_ip4_u32(&dst_addr, htonl(re_node->addr));
+#else
 				dst_addr.addr = htonl(re_node->addr);
+#endif
 				if(ip_addr_ismulticast(&dst_addr)){
 					struct ip_mreq imr;
 					struct in_addr intfAddr;

--- a/component/common/api/at_cmd/atcmd_wifi.c
+++ b/component/common/api/at_cmd/atcmd_wifi.c
@@ -265,7 +265,7 @@ static void print_scan_result( rtw_scan_result_t* record )
                                  ( record->security == RTW_SECURITY_WPA_WPA2_AES_ENTERPRISE ) ? "WPA/WPA2 AES Enterprise" :
                                  ( record->security == RTW_SECURITY_WPA_WPA2_MIXED_ENTERPRISE ) ? "WPA/WPA2 Mixed Enterprise" :
 #ifdef CONFIG_SAE_SUPPORT
-								 ( record->security == RTW_SECURITY_WPA3_AES_PSK) ? "WP3-SAE AES" :
+								 ( record->security == RTW_SECURITY_WPA3_AES_PSK) ? "WPA3-SAE AES" :
 								 ( record->security == RTW_SECURITY_WPA2_WPA3_MIXED) ? "WPA2/WPA3-SAE AES" :
 #endif
                                  "Unknown");
@@ -3029,11 +3029,20 @@ void atcmd_wifi_write_info_to_flash(rtw_wifi_setting_t *setting, int enable)
 						memcpy(psk_passphrase[index], setting->password, sizeof(psk_passphrase[index]));
 						reconn.security_type = RTW_SECURITY_WEP_PSK;
 						break;
+					case RTW_SECURITY_WPA_AES_PSK:
 					case RTW_SECURITY_WPA_TKIP_PSK:
-						reconn.security_type = RTW_SECURITY_WPA_TKIP_PSK;
-						break;
+					case RTW_SECURITY_WPA_MIXED_PSK:
 					case RTW_SECURITY_WPA2_AES_PSK:
-						reconn.security_type = RTW_SECURITY_WPA2_AES_PSK;
+					case RTW_SECURITY_WPA2_TKIP_PSK:
+					case RTW_SECURITY_WPA2_MIXED_PSK:
+					case RTW_SECURITY_WPA_WPA2_AES_PSK:
+					case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
+					case RTW_SECURITY_WPA_WPA2_MIXED_PSK:
+#ifdef CONFIG_SAE_SUPPORT
+					case RTW_SECURITY_WPA3_AES_PSK:
+					case RTW_SECURITY_WPA2_WPA3_MIXED:
+#endif
+						reconn.security_type = setting->security_type;
 						break;
 					default:
 						break;
@@ -3170,8 +3179,19 @@ int atcmd_wifi_restore_from_flash(void)
 					wifi.password_len = strlen((char*)psk_passphrase);
 					wifi.key_id = atoi((const char *)key_id);
 					break;
+				case RTW_SECURITY_WPA_AES_PSK:
 				case RTW_SECURITY_WPA_TKIP_PSK:
+				case RTW_SECURITY_WPA_MIXED_PSK:
 				case RTW_SECURITY_WPA2_AES_PSK:
+				case RTW_SECURITY_WPA2_TKIP_PSK:
+				case RTW_SECURITY_WPA2_MIXED_PSK:
+				case RTW_SECURITY_WPA_WPA2_AES_PSK:
+				case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
+				case RTW_SECURITY_WPA_WPA2_MIXED_PSK:
+#ifdef CONFIG_SAE_SUPPORT
+				case RTW_SECURITY_WPA3_AES_PSK:
+				case RTW_SECURITY_WPA2_WPA3_MIXED:
+#endif
 					wifi.password = (unsigned char*) psk_passphrase;
 					wifi.password_len = strlen((char*)psk_passphrase);
 					break;

--- a/component/common/api/network/src/ping_test.c
+++ b/component/common/api/network/src/ping_test.c
@@ -1,7 +1,7 @@
+#include "osdep_service.h"
 #include "FreeRTOS.h"
 #include "task.h"
 #include "main.h"
-
 #include <lwip/sockets.h>
 #include <lwip/raw.h>
 #include <lwip/icmp.h>
@@ -21,16 +21,20 @@
 
 static unsigned short ping_seq = 0;
 static int infinite_loop, ping_count, data_size, ping_interval, ping_call;
-
-
 static int ping_total_time = 0, ping_received_count = 0;
+static unsigned char g_ping_terminate = 0;
+xTaskHandle g_ping_task = NULL;
+unsigned char *ping_buf = NULL;
+unsigned char  *reply_buf = NULL;
+int ping_socket;
+
 
 static void generate_ping_echo(unsigned char *buf, int size)
 {
 	int i;
 	struct icmp_echo_hdr *pecho;
 
-	for(i = 0; i < size; i ++) {
+	for (i = 0; i < size; i ++) {
 		buf[sizeof(struct icmp_echo_hdr) + i] = (unsigned char) i;
 	}
 
@@ -50,7 +54,7 @@ static void generate_ping_echo_6(unsigned char *buf, int size)
 	int i;
 	struct icmp_echo_hdr *pecho;
 
-	for(i = 0; i < size; i ++) {
+	for (i = 0; i < size; i ++) {
 		buf[sizeof(struct icmp_echo_hdr) + i] = (unsigned char) i;
 	}
 
@@ -68,14 +72,15 @@ static void generate_ping_echo_6(unsigned char *buf, int size)
 extern struct netif xnetif[];
 void ping_test(void *param)
 {
-	int i, ping_socket;
+	int i;
+	//int ping_socket;
 	int pint_timeout = PING_TO;
-	struct sockaddr_in to_addr, from_addr;
+	struct sockaddr_in to_addr, from_addr, src_addr;
 	int from_addr_len = sizeof(struct sockaddr);
 	int ping_size, reply_size, ret_size;
-	unsigned char *ping_buf = NULL;
-	unsigned char *reply_buf = NULL;
+	//unsigned char *ping_buf, *reply_buf;
 	unsigned int ping_time, reply_time;
+	//struct ip_hdr *iphdr;
 	struct icmp_echo_hdr *pecho;
 	unsigned int min_time = 1000, max_time = 0;
 	struct hostent *server_host;
@@ -88,12 +93,12 @@ void ping_test(void *param)
 	ip6_addr_t *dest_addr6 = NULL;
 	unsigned int recv_time;
 #endif
-
+	vTaskDelay(100);//wait log service thread done
 	ping_total_time = 0;
 	ping_received_count = 0;
-	
-	if(data_size > BUF_SIZE){
-		printf("\n\r[ERROR] %s: data size error, can't exceed %d",__func__,BUF_SIZE);
+
+	if (data_size > BUF_SIZE) {
+		printf("\n\r[ERROR] %s: data size error, can't exceed %d\n", __func__, BUF_SIZE);
 		goto Exit;
 	}
 
@@ -101,17 +106,16 @@ void ping_test(void *param)
 	ping_size = sizeof(struct icmp_echo_hdr) + data_size;
 
 	ping_buf = pvPortMalloc(ping_size);
-	if(NULL == ping_buf){
-		printf("\n\r[ERROR] %s: Allocate ping_buf failed",__func__);
+	if (NULL == ping_buf) {
+		printf("\n\r[ERROR] %s: Allocate ping_buf failed\n", __func__);
 		goto Exit;
 	}
-	printf("\n\r[%s] PING %s %d(%d) bytes of data\n", __FUNCTION__, host, data_size, sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr) + data_size);			
 
 #if LWIP_IPV6
-	if(inet_pton(AF_INET6, host, &to_addr6.sin6_addr)){
+	if (inet_pton(AF_INET6, host, &to_addr6.sin6_addr)) {
 		ping_addr_is_ipv6 = 1;
 		reply_size = ping_size + IP6_HLEN;
-	}else{
+	} else {
 		ping_addr_is_ipv6 = 0;
 #endif
 		reply_size = ping_size + IP_HLEN;
@@ -120,32 +124,35 @@ void ping_test(void *param)
 #endif
 
 	reply_buf = pvPortMalloc(reply_size);
-	if(NULL == reply_buf){
-		printf("\n\r[ERROR] %s: Allocate reply_buf failed",__func__);
+	if (NULL == reply_buf) {
+		vPortFree(ping_buf);
+		printf("\n\r[ERROR] %s: Allocate reply_buf failed\n", __func__);
 		goto Exit;
 	}
 
-	for(i = 0; (i < ping_count) || (infinite_loop == 1); i ++) {
+	printf("\n\r[%s] PING %s %d(%d) bytes of data\n", __FUNCTION__, host, data_size, sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr) + data_size);
+
+	for (i = 0; ((i < ping_count) || (infinite_loop == 1)) && (!g_ping_terminate); i ++) {
 #if LWIP_IPV6
-		if(ping_addr_is_ipv6)
+		if (ping_addr_is_ipv6) {
 			ping_socket = socket(AF_INET6, SOCK_RAW, IP6_NEXTH_ICMP6);
-		else
+		} else
 #endif
-		ping_socket = socket(AF_INET, SOCK_RAW, IP_PROTO_ICMP);
-		if(ping_socket < 0){
+			ping_socket = socket(AF_INET, SOCK_RAW, IP_PROTO_ICMP);
+		if (ping_socket < 0) {
 			printf("create socket failed\r\n");
 		}
 #if defined(LWIP_SO_SNDRCVTIMEO_NONSTANDARD) && (LWIP_SO_SNDRCVTIMEO_NONSTANDARD == 0)	// lwip 1.5.0
 		struct timeval timeout;
 		timeout.tv_sec = pint_timeout / 1000;
 		timeout.tv_usec = pint_timeout % 1000 * 1000;
-		if(setsockopt(ping_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0){
+		if (setsockopt(ping_socket, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
 			printf("\n\r[%s] Set sockopt failed\n", __func__);
 			close(ping_socket);
 			goto Exit;
 		}
 #else	// lwip 1.4.1
-		if(setsockopt(ping_socket, SOL_SOCKET, SO_RCVTIMEO, &pint_timeout, sizeof(pint_timeout)) != 0){
+		if (setsockopt(ping_socket, SOL_SOCKET, SO_RCVTIMEO, &pint_timeout, sizeof(pint_timeout)) != 0) {
 			printf("\n\r[%s] Set sockopt failed\n", __func__);
 			close(ping_socket);
 			goto Exit;
@@ -154,46 +161,52 @@ void ping_test(void *param)
 
 #if LWIP_IPV6
 		dest_addr6 = pvPortMalloc(sizeof(ip6_addr_t));
-		if(NULL == dest_addr6){
-			printf("\n\r[ERROR] %s: Allocate dest_addr6 failed",__func__);
+		if (NULL == dest_addr6) {
+			printf("\n\r[ERROR] %s: Allocate dest_addr6 failed", __func__);
 			goto Exit;
 		}
 
-		if(ping_addr_is_ipv6){
+		if (ping_addr_is_ipv6) {
 			inet6_addr_to_ip6addr(dest_addr6, &to_addr6.sin6_addr);
 		}
-		if(ping_addr_is_ipv6 && ip6_addr_islinklocal(dest_addr6)){
+		if (ping_addr_is_ipv6 && ip6_addr_islinklocal(dest_addr6)) {
 			memset(&src_addr6, 0, sizeof(src_addr6));
 			src_addr6.sin6_family = AF_INET6;
 			src_addr6.sin6_port = 0;
-			inet6_addr_from_ip6addr(&src_addr6.sin6_addr, (ip6_addr_t*)&xnetif[0].ip6_addr[0]);
-			if(bind(ping_socket, (struct sockaddr*)&src_addr6, sizeof(src_addr6)) != 0){
+			inet6_addr_from_ip6addr(&src_addr6.sin6_addr, (ip6_addr_t *)&xnetif[0].ip6_addr[0]);
+			if (bind(ping_socket, (struct sockaddr *)&src_addr6, sizeof(src_addr6)) != 0) {
 				printf("\n\r[ERROR] Bind socket failed\n");
 				closesocket(ping_socket);
-				return;
+				goto Exit;
 			}
 		}
 #endif
 
 #if LWIP_IPV6
-		if(ping_addr_is_ipv6){
+		if (ping_addr_is_ipv6) {
 			to_addr6.sin6_len = sizeof(to_addr6);
 			to_addr6.sin6_family = AF_INET6;
-		}
-		else
+		} else
 #endif
 		{
+			memset(&src_addr, 0, sizeof(src_addr));
+			src_addr.sin_family = AF_INET;
+			src_addr.sin_port = 0;
+			inet_addr_from_ip4addr(&src_addr.sin_addr, (ip4_addr_t *)&xnetif[0].ip_addr);
+
+			if (bind(ping_socket, (struct sockaddr *) &src_addr, sizeof(src_addr)) != 0) {
+				printf("ERROR: bind\n");
+			}
 			to_addr.sin_len = sizeof(to_addr);
 			to_addr.sin_family = AF_INET;
 		}
 		if ((inet_aton(host, &to_addr.sin_addr) == 0)
 #if LWIP_IPV6
-		 && (inet6_aton(host, &to_addr6.sin6_addr) == 0)
+			&& (inet6_aton(host, &to_addr6.sin6_addr) == 0)
 #endif
-		)
-		{
+		   ) {
 			server_host = gethostbyname(host);
-			if(server_host == NULL){
+			if (server_host == NULL) {
 				printf("\n\r[%s] Get host name failed in the %d ping test\n", __FUNCTION__, (i + 1));
 				close(ping_socket);
 				vTaskDelay(ping_interval * configTICK_RATE_HZ);
@@ -202,7 +215,7 @@ void ping_test(void *param)
 			memcpy((void *) &to_addr.sin_addr, (void *) server_host->h_addr, 4);
 		}
 #if LWIP_IPV6
-		else if(ping_addr_is_ipv6){	
+		else if (ping_addr_is_ipv6) {
 			inet6_aton(host, &to_addr6.sin6_addr);
 		}
 #endif
@@ -211,95 +224,119 @@ void ping_test(void *param)
 		}
 
 #if LWIP_IPV6
-		if(ping_addr_is_ipv6){
+		if (ping_addr_is_ipv6) {
 			generate_ping_echo_6(ping_buf, data_size);
 			sendto(ping_socket, ping_buf, ping_size, 0, (struct sockaddr *) &to_addr6, sizeof(to_addr6));
-		}
-		else
+		} else
 #endif
 		{
 			generate_ping_echo(ping_buf, data_size);
 			sendto(ping_socket, ping_buf, ping_size, 0, (struct sockaddr *) &to_addr, sizeof(to_addr));
 		}
-		
+
 		ping_time = xTaskGetTickCount();
 #if LWIP_IPV6
-		if(ping_addr_is_ipv6)
+		if (ping_addr_is_ipv6) {
 			pecho = (struct icmp_echo_hdr *)(reply_buf + IP6_HLEN);
-		else
+		} else
 #endif
 			pecho = (struct icmp_echo_hdr *)(reply_buf + IP_HLEN);
 
 #if LWIP_IPV6
-	if(ping_addr_is_ipv6){
-		ret_size = recvfrom(ping_socket, reply_buf, reply_size, 0, (struct sockaddr *) &from_addr6, (socklen_t *) &from_addr6_len);
-		if(!memcmp((void *)&from_addr6.sin6_addr, (void *)&to_addr6.sin6_addr, sizeof(from_addr6.sin6_addr)))
-			ipv6_addr_equal = TRUE;
-		recv_time = xTaskGetTickCount();
-		//keep receiving until get Echo reply frame from ping destination
-		while((pecho->type != ICMP6_TYPE_EREP)||(ipv6_addr_equal != TRUE)){
+		if (ping_addr_is_ipv6) {
 			ret_size = recvfrom(ping_socket, reply_buf, reply_size, 0, (struct sockaddr *) &from_addr6, (socklen_t *) &from_addr6_len);
-			if(!memcmp((void *)&from_addr6.sin6_addr, (void *)&to_addr6.sin6_addr, sizeof(from_addr6.sin6_addr)))
+			if (!memcmp((void *)&from_addr6.sin6_addr, (void *)&to_addr6.sin6_addr, sizeof(from_addr6.sin6_addr))) {
 				ipv6_addr_equal = TRUE;
-			if((xTaskGetTickCount() - recv_time) > 5000)
-				break;
-		}
-	}
-	else
-#endif
-		ret_size = recvfrom(ping_socket, reply_buf, reply_size, 0, (struct sockaddr *) &from_addr, (socklen_t *) &from_addr_len);
-
-		if(ret_size >= (int)(sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr))) {
-			reply_time = xTaskGetTickCount();
-#if LWIP_IPV6
-			if(ping_addr_is_ipv6 && ipv6_addr_equal){
-				if((pecho->id == PING_ID_6) && (pecho->seqno == htons(ping_seq))) {
-					printf("\n\r[%s] %d bytes from %s: icmp_seq=%d time=%d ms", __FUNCTION__, data_size, inet6_ntoa(from_addr6.sin6_addr), htons(pecho->seqno), (reply_time - ping_time) * portTICK_RATE_MS);
-					ping_received_count++;
-					ping_total_time += (reply_time - ping_time) * portTICK_RATE_MS;
-					if((reply_time - ping_time) > max_time) max_time = (reply_time - ping_time);
-					if((reply_time - ping_time) < min_time) min_time = (reply_time - ping_time);
+			}
+			recv_time = xTaskGetTickCount();
+			//keep receiving until get Echo reply frame from ping destination
+			while ((pecho->type != ICMP6_TYPE_EREP) || (ipv6_addr_equal != TRUE)) {
+				ret_size = recvfrom(ping_socket, reply_buf, reply_size, 0, (struct sockaddr *) &from_addr6, (socklen_t *) &from_addr6_len);
+				if (!memcmp((void *)&from_addr6.sin6_addr, (void *)&to_addr6.sin6_addr, sizeof(from_addr6.sin6_addr))) {
+					ipv6_addr_equal = TRUE;
+				}
+				if ((xTaskGetTickCount() - recv_time) > 5000) {
+					break;
 				}
 			}
-			else
-#endif 
-				 if(from_addr.sin_addr.s_addr == to_addr.sin_addr.s_addr){
-				if((pecho->id == PING_ID) && (pecho->seqno == htons(ping_seq))) {
-					printf("\n\r[%s] %d bytes from %s: icmp_seq=%d time=%d ms", __FUNCTION__, data_size, inet_ntoa(from_addr.sin_addr), htons(pecho->seqno), (reply_time - ping_time) * portTICK_RATE_MS);
+		} else
+#endif
+			ret_size = recvfrom(ping_socket, reply_buf, reply_size, 0, (struct sockaddr *) &from_addr, (socklen_t *) &from_addr_len);
+
+		if (ret_size >= (int)(sizeof(struct ip_hdr) + sizeof(struct icmp_echo_hdr))) {
+			reply_time = xTaskGetTickCount();
+#if LWIP_IPV6
+			if (ping_addr_is_ipv6 && ipv6_addr_equal) {
+				if ((pecho->id == PING_ID_6) && (pecho->seqno == htons(ping_seq))) {
+					printf("\n\r[%s] %d bytes from %s: icmp_seq=%d time=%d ms", __FUNCTION__, data_size, inet6_ntoa(from_addr6.sin6_addr), htons(pecho->seqno),
+						   (reply_time - ping_time) * portTICK_RATE_MS);
 					ping_received_count++;
 					ping_total_time += (reply_time - ping_time) * portTICK_RATE_MS;
-					if((reply_time - ping_time) > max_time) max_time = (reply_time - ping_time);
-					if((reply_time - ping_time) < min_time) min_time = (reply_time - ping_time);
-				}	
-			}
-			else
-				printf("\n\r[%s] Request timeout for icmp_seq %d\n", __FUNCTION__, ping_seq);
-		}
-		else
+					if ((reply_time - ping_time) > max_time) {
+						max_time = (reply_time - ping_time);
+					}
+					if ((reply_time - ping_time) < min_time) {
+						min_time = (reply_time - ping_time);
+					}
+				}
+			} else
+#endif
+				if (from_addr.sin_addr.s_addr == to_addr.sin_addr.s_addr) {
+					if ((pecho->id == PING_ID) && (pecho->seqno == htons(ping_seq))) {
+						printf("\n\r[%s] %d bytes from %s: icmp_seq=%d time=%d ms", __FUNCTION__, data_size, inet_ntoa(from_addr.sin_addr), htons(pecho->seqno),
+							   (reply_time - ping_time) * portTICK_RATE_MS);
+						ping_received_count++;
+						ping_total_time += (reply_time - ping_time) * portTICK_RATE_MS;
+						if ((reply_time - ping_time) > max_time) {
+							max_time = (reply_time - ping_time);
+						}
+						if ((reply_time - ping_time) < min_time) {
+							min_time = (reply_time - ping_time);
+						}
+					}
+				} else {
+					printf("\n\r[%s] Request timeout for icmp_seq %d\n", __FUNCTION__, ping_seq);
+				}
+		} else {
 			printf("\n\r[%s] Request timeout for icmp_seq %d\n", __FUNCTION__, ping_seq);
+		}
 
 		close(ping_socket);
 		vTaskDelay(ping_interval * configTICK_RATE_HZ);
 	}
-	if(ping_count == 0){
-		printf("\n\rNumber of echo requests to send cannot be zero\n\r");
+	if (g_ping_terminate) {
+		printf("\n[%s] ping test terminate!\n", __FUNCTION__);
+		ping_count = i;
 	}
-	else{
-		printf("\n\r[%s] %d packets transmitted, %d received, %d%% packet loss, average %d ms", __FUNCTION__, ping_count, ping_received_count, (ping_count-ping_received_count)*100/ping_count, ping_received_count ? ping_total_time/ping_received_count : 0);
+	if (ping_count == 0) {
+		printf("\n\rNumber of echo requests to send cannot be zero\n\r");
+	} else {
+		printf("\n\r[%s] %d packets transmitted, %d received, %d%% packet loss, average %d ms", __FUNCTION__, ping_count, ping_received_count,
+			   (ping_count - ping_received_count) * 100 / ping_count, ping_received_count ? ping_total_time / ping_received_count : 0);
 		printf("\n\r[%s] min: %d ms, max: %d ms\n\r", __FUNCTION__, min_time, max_time);
 	}
 Exit:
-	if(ping_buf)
+	if (ping_buf) {
 		vPortFree(ping_buf);
-	if(reply_buf)
+		ping_buf = NULL;
+	}
+	if (reply_buf) {
 		vPortFree(reply_buf);
+		reply_buf = NULL;
+	}
+	if (host) {
+		vPortFree(host);
+	}
 #if LWIP_IPV6
-	if(dest_addr6)
+	if (dest_addr6) {
 		vPortFree(dest_addr6);
+	}
 #endif
 
-	if(!ping_call)
+	if (!ping_call) {
+		g_ping_task = NULL;
 		vTaskDelete(NULL);
+	}
 }
 
 void do_ping_call(char *ip, int loop, int count)
@@ -310,93 +347,115 @@ void do_ping_call(char *ip, int loop, int count)
 	ping_interval = 1;
 	infinite_loop = loop;
 	ping_count = count;
-	char * host;
+	char *host;
 	host = pvPortMalloc(strlen(ip) + 1);
 	memset(host, 0, (strlen(ip) + 1));
 	memcpy(host, ip, strlen(ip));
 	ping_test(host);
 }
 
-int get_ping_report(int *ping_lost){
+int get_ping_report(int *ping_lost)
+{
 	*ping_lost = ping_count - ping_received_count;
 	return 0;
 }
 
 void cmd_ping(int argc, char **argv)
 {
-    int argv_count = 2;
-	char * host;
+	int argv_count = 2;
+	int argv_count_len = 0;
+	char *host;
 
-    if(argc < 2)
-        goto Exit;
+	g_ping_terminate = 0;
+	if (argc < 2) {
+		goto Exit;
+	}
 
-    //ping cmd default value
-    infinite_loop = 0;
-    ping_count    = 4;
-    data_size     = 32;
-    ping_interval = 1;
-    ping_call     = 1;
-    ping_seq      = 0;
+	while (argv_count <= argc) {
+		//first operation
+		if (argv_count == 2) {
+			if (strcmp(argv[argv_count - 1], "stop") == 0) {
+				if (argc == 2) {
+					g_ping_terminate = 1;
+					//vTaskDelay(100);
+					return;
+				} else {
+					goto Exit;
+				}
+			} else {
+				if (g_ping_task) {
+					printf("\n\rPing: Ping task is already running.\n");
+					return;
+				} else {
+					//ping cmd default value
+					infinite_loop = 0;
+					ping_count    = 4;
+					data_size     = 32;
+					ping_interval = 1;
+					ping_call     = 0;
+					ping_seq      = 0;
+					argv_count_len = strlen(argv[argv_count - 1]);
+					host = pvPortMalloc(argv_count_len + 1);
+					memset(host, 0, (argv_count_len + 1));
+					strncpy(host, argv[argv_count - 1], argv_count_len);
+					argv_count++;
+				}
+			}
+		} else {
+			if (strcmp(argv[argv_count - 1], "-t") == 0) {
+				infinite_loop = 1;
+				argv_count++;
+			} else if (strcmp(argv[argv_count - 1], "-n") == 0) {
+				if (argc < (argv_count + 1)) {
+					goto Exit;
+				}
+				ping_count = (int) atoi(argv[argv_count]);
+				argv_count += 2;
+			} else if (strcmp(argv[argv_count - 1], "-l") == 0) {
+				if (argc < (argv_count + 1)) {
+					goto Exit;
+				}
+				data_size = (int) atoi(argv[argv_count]);
+				argv_count += 2;
+			} else {
+				goto Exit;
+			}
+		}
+	}
 
-    while(argv_count<=argc){
-        //first operation
-        if(argv_count == 2){
-            host = pvPortMalloc(strlen(argv[argv_count-1]) + 1);
-            memset(host, 0, (strlen(argv[argv_count-1]) + 1));
-            strncpy(host, argv[argv_count-1], strlen(argv[argv_count-1]));
-            argv_count++;
-        }
-        else{
-            if(strcmp(argv[argv_count-1], "-t") == 0){
-                infinite_loop = 1;
-                argv_count++;
-            }
-            else if(strcmp(argv[argv_count-1], "-n") == 0){
-                if(argc < (argv_count+1))
-                    goto Exit;
-                ping_count = (int) atoi(argv[argv_count]);
-                argv_count+=2;
-            }
-            else if(strcmp(argv[argv_count-1], "-l") == 0){
-                if(argc < (argv_count+1))
-                    goto Exit;
-                data_size = (int) atoi(argv[argv_count]);
-                argv_count+=2;
-            }
-            else{
-                goto Exit;
-            }
-        }
-    }
+	if (g_ping_task == NULL) {
+		if (xTaskCreate(ping_test, (char const *)((const signed char *)"ping_test"), STACKSIZE, host, tskIDLE_PRIORITY + 1 + PRIORITIE_OFFSET,
+						&g_ping_task) != pdPASS) {
+			printf("\n\r Ping ERROR: Create ping task failed.");
+		}
+	}
 
-    ping_test(host);
-
-    return;
+	return;
 
 Exit:
-    printf("\n\r[ATWI] Usage: ATWI=[host],[options]\n");
-    printf("\n\r     -t        Ping the specified host until stopped\n");
-    printf("  \r     -n    #   Number of echo requests to send (default 4 times)\n");
-    printf("  \r     -l    #   Send buffer size (default 32 bytes)\n");
-    printf("\n\r   Example:\n");
-    printf("  \r     ATWI=192.168.1.2,-n,100,-l,5000\n");
-    return;
+	printf("\n\r[ATWI] Usage: ATWI=[host],[options]\n");
+	printf("\n\r     stop      Terminate ping \n");
+	printf("  \r     -t    #   Ping the specified host until stopped\n");
+	printf("  \r     -n   #   Number of echo requests to send (default 4 times)\n");
+	printf("  \r     -l    #   Send buffer size (default 32 bytes)\n");
+	printf("\n\r   Example:\n");
+	printf("  \r     ATWI=192.168.1.2,-n,100,-l,5000\n");
+	return;
 }
 
 void do_ping_test(char *ip, int size, int count, int interval)
 {
 	char *host;
-	if((sizeof(struct icmp_echo_hdr) + size) > BUF_SIZE) {
+	if ((sizeof(struct icmp_echo_hdr) + size) > BUF_SIZE) {
 		printf("\n\r%s BUF_SIZE(%d) is too small", __FUNCTION__, BUF_SIZE);
 		return;
 	}
 
-	if(ip == NULL){
+	if (ip == NULL) {
 		host = pvPortMalloc(strlen(PING_IP) + 1);
 		memset(host, 0, (strlen(PING_IP) + 1));
 		strncpy(host, PING_IP, (strlen(PING_IP) + 1));
-	}
-	else{
+	} else {
 		host = pvPortMalloc(strlen(ip) + 1);
 		memset(host, 0, (strlen(ip) + 1));
 		strncpy(host, ip, (strlen(PING_IP) + 1));
@@ -407,15 +466,15 @@ void do_ping_test(char *ip, int size, int count, int interval)
 	data_size = size;
 	ping_interval = interval;
 
-	if(count == 0) {
+	if (count == 0) {
 		infinite_loop = 1;
 		ping_count = 0;
-	}
-	else {
+	} else {
 		infinite_loop = 0;
 		ping_count = count;
 	}
 
-	if(xTaskCreate(ping_test, (char const*)((const signed char*)"ping_test"), STACKSIZE, host, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+	if (xTaskCreate(ping_test, (char const *)((const signed char *)"ping_test"), STACKSIZE, host, tskIDLE_PRIORITY + 1, NULL) != pdPASS) {
 		printf("\n\r%s xTaskCreate failed", __FUNCTION__);
+	}
 }

--- a/component/common/api/wifi/wifi_conf.c
+++ b/component/common/api/wifi/wifi_conf.c
@@ -773,20 +773,21 @@ void restore_wifi_info_to_flash(uint32_t offer_ip, uint32_t server_ip)
 			    rtw_memcpy(psk_passphrase[index], setting.password, sizeof(psk_passphrase[index]));
 			    wifi_data_to_flash.security_type = RTW_SECURITY_WEP_PSK;
 			    break;
+			case RTW_SECURITY_WPA_AES_PSK:
 			case RTW_SECURITY_WPA_TKIP_PSK:
-				wifi_data_to_flash.security_type = RTW_SECURITY_WPA_TKIP_PSK;
-                break;
+			case RTW_SECURITY_WPA_MIXED_PSK:
 			case RTW_SECURITY_WPA2_AES_PSK:
-				wifi_data_to_flash.security_type = RTW_SECURITY_WPA2_AES_PSK;
-			    break;
+			case RTW_SECURITY_WPA2_TKIP_PSK:
+			case RTW_SECURITY_WPA2_MIXED_PSK:
+			case RTW_SECURITY_WPA_WPA2_AES_PSK:
+			case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
+			case RTW_SECURITY_WPA_WPA2_MIXED_PSK:
 #ifdef CONFIG_SAE_SUPPORT
 			case RTW_SECURITY_WPA3_AES_PSK:
-				 wifi_data_to_flash.security_type = RTW_SECURITY_WPA3_AES_PSK;
-				break;
 			case RTW_SECURITY_WPA2_WPA3_MIXED:
-				 wifi_data_to_flash.security_type = RTW_SECURITY_WPA2_WPA3_MIXED;
-				break;
 #endif
+				wifi_data_to_flash.security_type = setting.security_type;
+				break;
 			default:
 			    break;
 		}

--- a/component/common/application/matter/common/port/matter_wifis.c
+++ b/component/common/application/matter/common/port/matter_wifis.c
@@ -404,7 +404,9 @@ void matter_lwip_dhcp()
 
 void matter_lwip_dhcp6(void)
 {
+#if defined(LWIP_IPV6) && LWIP_IPV6
     LwIP_DHCP6(0, DHCP6_START);
+#endif
 }
 
 void matter_lwip_releaseip(void)

--- a/component/common/application/matter/example/aircon/example_matter_aircon.cpp
+++ b/component/common/application/matter/example/aircon/example_matter_aircon.cpp
@@ -11,6 +11,7 @@
 #include "matter_drivers.h"
 #include "matter_interaction.h"
 
+#if defined(CONFIG_EXAMPLE_MATTER_AIRCON) && CONFIG_EXAMPLE_MATTER_AIRCON
 static void example_matter_aircon_task(void *pvParameters)
 {
     while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
@@ -55,3 +56,4 @@ extern "C" void example_matter_aircon(void)
     if(xTaskCreate(example_matter_aircon_task, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
         ChipLogProgress(DeviceLayer, "\n\r%s xTaskCreate(example_matter_aircon) failed", __FUNCTION__);
 }
+#endif /* CONFIG_EXAMPLE_MATTER_AIRCON */

--- a/component/common/application/matter/example/chiptest/example_matter.c
+++ b/component/common/application/matter/example/chiptest/example_matter.c
@@ -7,6 +7,7 @@
 #include "wifi_constants.h"
 #include "wifi/wifi_conf.h"
 
+#if defined(CONFIG_EXAMPLE_MATTER_CHIPTEST) && CONFIG_EXAMPLE_MATTER_CHIPTEST
 extern void ChipTest(void);
 
 static void example_matter_task_thread(void *pvParameters)
@@ -28,3 +29,4 @@ void example_matter_task(void)
     if(xTaskCreate(example_matter_task_thread, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
         printf("\n\r%s xTaskCreate(example_matter_task_thread) failed", __FUNCTION__);
 }
+#endif /* CONFIG_EXAMPLE_MATTER_CHIPTEST */

--- a/component/common/application/matter/example/light/example_matter_light.cpp
+++ b/component/common/application/matter/example/light/example_matter_light.cpp
@@ -11,6 +11,7 @@
 #include "matter_drivers.h"
 #include "matter_interaction.h"
 
+#if defined(CONFIG_EXAMPLE_MATTER_LIGHT) && CONFIG_EXAMPLE_MATTER_LIGHT
 static void example_matter_light_task(void *pvParameters)
 {
     while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
@@ -55,3 +56,4 @@ extern "C" void example_matter_light(void)
     if(xTaskCreate(example_matter_light_task, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
         ChipLogProgress(DeviceLayer, "\n\r%s xTaskCreate(example_matter_light) failed", __FUNCTION__);
 }
+#endif /* CONFIG_EXAMPLE_MATTER_LIGHT */

--- a/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
+++ b/component/common/application/matter/example/thermostat/example_matter_thermostat.cpp
@@ -11,6 +11,7 @@
 #include "matter_drivers.h"
 #include "matter_interaction.h"
 
+#if defined(CONFIG_EXAMPLE_MATTER_THERMOSTAT) && CONFIG_EXAMPLE_MATTER_THERMOSTAT
 static void example_matter_thermostat_task(void *pvParameters)
 {
     while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
@@ -55,3 +56,4 @@ extern "C" void example_matter_thermostat(void)
     if(xTaskCreate(example_matter_thermostat_task, ((const char*)"example_matter_task_thread"), 2048, NULL, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
         ChipLogProgress(DeviceLayer, "\n\r%s xTaskCreate(example_matter_thermostat) failed", __FUNCTION__);
 }
+#endif /* CONFIG_EXAMPLE_MATTER_THERMOSTAT */

--- a/component/common/example/example_entry.c
+++ b/component/common/example/example_entry.c
@@ -291,7 +291,7 @@
 #endif
 
 #if defined(CONFIG_EXAMPLE_CJSON) && CONFIG_EXAMPLE_CJSON
-#include <cjson/example_cJSON.h>
+#include <cJSON/example_cJSON.h>
 #endif
 	
 #if defined(CONFIG_MEDIA_H264_TO_SDCARD) && CONFIG_MEDIA_H264_TO_SDCARD

--- a/component/common/example/httpd/readme.txt
+++ b/component/common/example/httpd/readme.txt
@@ -42,6 +42,11 @@ AmebaPro and AmebaZ2 only support MBEDTLS.
 			For AmebaPro and Ameba-Z2:
 				#define MBEDTLS_CERTS_C
 				#define MBEDTLS_SSL_SRV_C
+For Matter:
+[component\common\application\matter\common\mbedtls\mbedtls_config.h]
+	For Ameba-Z2:
+	#define MBEDTLS_CERTS_C
+	#define MBEDTLS_SSL_SRV_C
 
         Can make automatical Wi-Fi connection when booting by using wlan fast connect example.
 		

--- a/component/common/example/socket_tcp_trx/example_socket_tcp_trx_1.c
+++ b/component/common/example/socket_tcp_trx/example_socket_tcp_trx_1.c
@@ -111,14 +111,14 @@ static void example_socket_tcp_trx_thread(void *param)
 			//RtlInitSema(&tcp_tx_rx_sema, 1);			
 			rtw_init_sema(&tcp_tx_rx_sema, 1);
 
-			if(xTaskCreate(tx_thread, ((const char*)"tx_thread"), 512, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+			if(xTaskCreate(tx_thread, ((const char*)"tx_thread"), 1024, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
 				printf("\n\r%s xTaskCreate(tx_thread) failed", __FUNCTION__);
 			else
 				tx_exit = 0;
 
 			vTaskDelay(10);
 
-			if(xTaskCreate(rx_thread, ((const char*)"rx_thread"), 512, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+			if(xTaskCreate(rx_thread, ((const char*)"rx_thread"), 1024, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
 				printf("\n\r%s xTaskCreate(rx_thread) failed", __FUNCTION__);
 			else
 				rx_exit = 0;

--- a/component/common/example/socket_tcp_trx/example_socket_tcp_trx_2.c
+++ b/component/common/example/socket_tcp_trx/example_socket_tcp_trx_2.c
@@ -90,14 +90,14 @@ static void example_socket_tcp_trx_thread(void *param)
 			tx_exit = 1;
 			rx_exit = 1;
 
-			if(xTaskCreate(tx_thread, ((const char*)"tx_thread"), 512, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+			if(xTaskCreate(tx_thread, ((const char*)"tx_thread"), 1024, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
 				printf("\n\r%s xTaskCreate(tx_thread) failed", __FUNCTION__);
 			else
 				tx_exit = 0;
 
 			vTaskDelay(10);
 
-			if(xTaskCreate(rx_thread, ((const char*)"rx_thread"), 512, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
+			if(xTaskCreate(rx_thread, ((const char*)"rx_thread"), 1024, &client_fd, tskIDLE_PRIORITY + 1, NULL) != pdPASS)
 				printf("\n\r%s xTaskCreate(rx_thread) failed", __FUNCTION__);
 			else
 				rx_exit = 0;

--- a/component/common/example/ssl_server/readme.txt
+++ b/component/common/example/ssl_server/readme.txt
@@ -16,6 +16,11 @@ For MbedTLS:
 	#define MBEDTLS_CERTS_C
 	#define MBEDTLS_SSL_SRV_C
 
+For Matter MbedTLS:
+[component\common\application\matter\common\mbedtls\mbedtls_config.h]
+	#define MBEDTLS_CERTS_C
+	#define MBEDTLS_SSL_SRV_C
+
 [platform_opts.h]
 	#define CONFIG_EXAMPLE_SSL_SERVER	1
 

--- a/component/common/example/wlan_fast_connect/example_wlan_fast_connect.c
+++ b/component/common/example/wlan_fast_connect/example_wlan_fast_connect.c
@@ -133,8 +133,15 @@ WIFI_RETRY_LOOP:
 				wifi.password_len = strlen((char*)psk_passphrase);
 				wifi.key_id = atoi((const char *)key_id);
 				break;
+			case RTW_SECURITY_WPA_AES_PSK:
 			case RTW_SECURITY_WPA_TKIP_PSK:
+			case RTW_SECURITY_WPA_MIXED_PSK:
 			case RTW_SECURITY_WPA2_AES_PSK:
+			case RTW_SECURITY_WPA2_TKIP_PSK:
+			case RTW_SECURITY_WPA2_MIXED_PSK:
+			case RTW_SECURITY_WPA_WPA2_AES_PSK:
+			case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
+			case RTW_SECURITY_WPA_WPA2_MIXED_PSK:
 #ifdef CONFIG_SAE_SUPPORT
 			case RTW_SECURITY_WPA3_AES_PSK:
 			case RTW_SECURITY_WPA2_WPA3_MIXED:
@@ -291,8 +298,15 @@ int wlan_init_done_callback(void)
 					wifi.password_len = strlen((char*)psk_passphrase);
 					wifi.key_id = atoi((const char *)key_id);
 					break;
+				case RTW_SECURITY_WPA_AES_PSK:
 				case RTW_SECURITY_WPA_TKIP_PSK:
+				case RTW_SECURITY_WPA_MIXED_PSK:
 				case RTW_SECURITY_WPA2_AES_PSK:
+				case RTW_SECURITY_WPA2_TKIP_PSK:
+				case RTW_SECURITY_WPA2_MIXED_PSK:
+				case RTW_SECURITY_WPA_WPA2_AES_PSK:
+				case RTW_SECURITY_WPA_WPA2_TKIP_PSK:
+				case RTW_SECURITY_WPA_WPA2_MIXED_PSK:
 #ifdef CONFIG_SAE_SUPPORT
 				case RTW_SECURITY_WPA3_AES_PSK:
 				case RTW_SECURITY_WPA2_WPA3_MIXED:

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/application.is.matter.mk
@@ -233,6 +233,8 @@ SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/
 #SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/hids_rmc.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/client/simple_ble_client.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/simple_ble_service.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/client/ota_client.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/src/ble/profile/client/dfu_client.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/board/common/src/trace_task.c
 
 #bluetooth - example - ble_central
@@ -250,6 +252,28 @@ SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_peripheral/
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_app_main.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_peripheral/ble_peripheral_at_cmd.c
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_peripheral/peripheral_app.c
+
+#bluetooth - example - ble_scatternet
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_scatternet_app.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_scatternet_app_main.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_scatternet_app_task.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/ble_scatternet/ble_scatternet_link_mgr.c
+
+#bluetooth - example - bt_fuzz_test
+#SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_app.c \
+	../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_app_main.c \
+	../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_app_task.c \
+	../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_at_cmd.c \
+	../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_link_mgr.c \
+	../../../component/common/bluetooth/realtek/sdk/example/bt_fuzz_test/bt_fuzz_test_simple_ble_service.c \
+	../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/gls.c \
+	../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/hrs.c \
+	../../../component/common/bluetooth/realtek/sdk/src/ble/profile/server/ias.c
+
+#bluetooth - example - bt_beacon
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_beacon/bt_beacon_app.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_beacon/bt_beacon_app_main.c
+SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_beacon/bt_beacon_app_task.c
 
 #bluetooth - example - bt_config
 SRC_C += ../../../component/common/bluetooth/realtek/sdk/example/bt_config/bt_config_app_main.c
@@ -327,7 +351,7 @@ SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_app_task.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_peripheral_app.c
 SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_service.c
-SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_wifi.c
+#SRC_C += ../../../component/common/application/matter/common/bluetooth/bt_matter_adapter/bt_matter_adapter_wifi.c
 endif
 endif
 

--- a/project/realtek_amebaz2_v0_example/example_sources/pm_sleepcg/src/main.c
+++ b/project/realtek_amebaz2_v0_example/example_sources/pm_sleepcg/src/main.c
@@ -28,7 +28,7 @@
 //wake up by UART      : 2
 //wake up by Gtimer    : 3
 //wake up by PWM       : 4
-#define WAKEUP_SOURCE 0
+#define WAKEUP_SOURCE 3
 //Clock, 1: 4MHz, 0: 250kHz
 #define CLOCK 0
 //SLEEP_DURATION, 5s
@@ -84,7 +84,6 @@ static int Gtimer_init_count = 0;
 static void Gtimer_timeout_handler (uint32_t id)
 {
     dbg_printf("Gtimer wake up   \r\n");
-    pwmout_period_int(&my_PWM, 0, 0); // disable interrupt to sync the count
 }
 #endif
 
@@ -100,6 +99,7 @@ extern void pwmout_period_int(pwmout_t *obj, pwm_period_callback_t callback, u8 
 static void PWM_period_handler (uint32_t id)
 {
     dbg_printf("PWM wake up   \r\n");
+    pwmout_period_int(&my_PWM, 0, 0); // disable interrupt to sync the count
 }
 #endif
 

--- a/project/realtek_amebaz2_v0_example/example_sources/pwm-buzzer/src/main.c
+++ b/project/realtek_amebaz2_v0_example/example_sources/pwm-buzzer/src/main.c
@@ -45,6 +45,7 @@ int main (void)
         for (i = 0; i < 8; i++) {
             pwmout_period(&pwm_led[0], period[i]);
             pwmout_pulsewidth(&pwm_led[0], (period[i]/2));
+            pwmout_start(&pwm_led[0]);
             hal_delay_ms(1000);
         }
 //        wait_ms(20);

--- a/project/realtek_amebaz2_v0_example/example_sources/pwm/src/main.c
+++ b/project/realtek_amebaz2_v0_example/example_sources/pwm/src/main.c
@@ -66,6 +66,7 @@ int main (void)
     for (i = 0; i < 4; i++) {
         pwmout_init(&pwm_led[i], pwm_led_pin[i]);
         pwmout_period_us(&pwm_led[i], PWM_PERIOD);
+        pwmout_start(&pwm_led[i]);
     }
 
     while (1) {

--- a/project/realtek_amebaz2_v0_example/inc/platform_opts.h
+++ b/project/realtek_amebaz2_v0_example/inc/platform_opts.h
@@ -433,6 +433,7 @@
 #define CONFIG_FAST_DHCP 0
 #endif
 
+#ifdef CHIP_PROJECT
 #if defined(CONFIG_EXAMPLE_MATTER) && (CONFIG_EXAMPLE_MATTER == 1)
 #undef CONFIG_EXAMPLE_WLAN_FAST_CONNECT
 #define CONFIG_EXAMPLE_WLAN_FAST_CONNECT	0
@@ -442,6 +443,7 @@
 #else
 #define CONFIG_FAST_DHCP 0
 #endif /* CONFIG_EXAMPLE_WLAN_FAST_CONNECT */
+#endif /* CONFIG_EXAMPLE_MATTER */
 
 // Matter layout
 #undef FAST_RECONNECT_DATA
@@ -460,4 +462,4 @@
 #define DCT_BEGIN_ADDR			(0x400000 - 0x13000) // 0x3ED000 ~ 0x3FB000 : 56K 
 #define DCT_BEGIN_ADDR2 		(0x400000 - 0x1A000) // 0x3E6000 ~ 0x3ED000 : 24K
 #define MATTER_FACTORY_DATA     (0x3FF000)           // last 4KB of external flash - write protection is supported in this region
-#endif /* defined(CONFIG_EXAMPLE_MATTER) && CONFIG_EXAMPLE_MATTER */
+#endif /* CHIP_PROJECT */


### PR DESCRIPTION
These changes is to fix issues was found during sdk quality check:
* fix compile error due to lwip_v2.1.2 when enabling CONFIG_EXAMPLE_UART_ATCMD
* fix spelling error when printing wifi scan result for WPA3
* fix compile error after enabling CONFIG_BT_CONFIG, CONFIG_BT_AIRSYNC_CONFIG, CONFIG_BT_SCATTERNET, CONFIG_BT_BEACON and CONFIG_BT_FUZZ_TEST
* fix heap leakage when performing ping_test continuously
* fix build error when disabling LWIP_IPV6
* Correct cJSON header path
* Modify readme to change mbedtls configuration for matter
* fix tcp example hardfault due stack overflow after enabling LWIP_TCPIP_CORE_LOCKING
* fix ota example hardfault due to not using the same flash layout defined in platform_opts.h
* fix peripheral example
* Support wpa/wpa2/wpa3 and other encryption type for fast connect and uart atcmd_lwip.c
* synchronize ping_test.c from trunk to prevent packet losses