### PR TITLE
[sdk] fix spic error when using rtw_opt_skbuf.c

### DIFF
--- a/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
@@ -203,7 +203,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
+++ b/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
@@ -198,7 +198,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
+++ b/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
@@ -195,7 +195,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -197,7 +197,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -202,7 +202,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
@@ -201,7 +201,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
+++ b/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
@@ -197,7 +197,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -202,7 +202,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/component/common/drivers/wlan/realtek/src/core/option/rtw_opt_skbuf.c
+++ b/component/common/drivers/wlan/realtek/src/core/option/rtw_opt_skbuf.c
@@ -1,13 +1,18 @@
 #include <section_config.h>
 #include <osdep_service.h>
 #include <skbuff.h>
+#include "autoconf.h"
 
 #ifdef CONFIG_PLATFORM_8710C
+#if (SKB_PRE_ALLOCATE_RX == 1)
+#define MAX_SKB_BUF_SIZE     2112
+#else
 #define MAX_SKB_BUF_SIZE     1658	// should >= the size in wlan driver
+#endif //(SKB_PRE_ALLOCATE_RX == 1)
 #else
 #define MAX_SKB_BUF_SIZE     1650	// should >= the size in wlan driver
 #endif
-#define MAX_SKB_BUF_NUM      8
+#define MAX_SKB_BUF_NUM      14		//14: High Performance test 8: Default
 #define MAX_LOCAL_SKB_NUM    (MAX_SKB_BUF_NUM + 2)
 
 /* DO NOT modify skb_buf and skb_data structure */
@@ -17,11 +22,22 @@ struct skb_buf {
 };
 
 struct skb_data {
-	struct list_head list;
+	/* starting address must be aligned by 32 bytes for km4 cache. */
+	struct list_head list __attribute__((aligned(32)));
 	unsigned char buf[MAX_SKB_BUF_SIZE];
-	atomic_t ref;
+	/* to protect ref when to invalid cache, its address must be
+	 * aligned by 32 bytes. */
+	atomic_t ref __attribute__((aligned(32)));
 };
 
+#if (SKB_PRE_ALLOCATE_RX == 1)
+u8 g_skb_pre_allocate_rx = 1; 		// 1: Enable, 0: Disable
+u8 g_exchange_lxbus_rx_skb = 1;		// 1: Enable, 0: Disable
+u8 g_rx_q_desc_num = 6;			// 6: High Performance Test, 4: Default
+#if (MAX_SKB_BUF_NUM == 8)
+#error "Value of MAX_SKB_BUF_NUM should be changed to 14 for High Performance Test"
+#endif
+#endif
 unsigned int nr_xmitframe = MAX_SKB_BUF_NUM;
 unsigned int nr_xmitbuff = MAX_SKB_BUF_NUM;
 int max_local_skb_num = MAX_LOCAL_SKB_NUM;
@@ -37,7 +53,7 @@ SRAM_BD_DATA_SECTION
 struct skb_data skb_data_pool[MAX_SKB_BUF_NUM];
 void skb_data_size_check(int size)
 {
-	if(size != MAX_SKB_BUF_SIZE){
+	if (size != MAX_SKB_BUF_SIZE) {
 		printf("\n\rAssert(%d == %d) failed on line %d in file %s", size, MAX_SKB_BUF_SIZE, __LINE__, __FILE__);
 		HALT();
 	}
@@ -45,7 +61,7 @@ void skb_data_size_check(int size)
 #else
 // Change to use heap (malloc) to save SRAM memory
 SRAM_BD_DATA_SECTION
-struct skb_data * skb_data_pool;
+struct skb_data *skb_data_pool;
 
 extern struct list_head skbdata_list;
 extern int skbdata_used_num;
@@ -57,25 +73,25 @@ void init_skb_data_pool(void)
 	skb_data_size_check(MAX_SKB_BUF_SIZE);
 	//printf("\ninit_skb_data_pool\n");
 	skb_data_pool = (struct skb_data *)rtw_zmalloc(max_skb_buf_num * sizeof(struct skb_data));
-	if(!skb_data_pool){
+	if (!skb_data_pool) {
 		printf("\nskb_data_pool alloc fail\n");
 		return;
 	}
-	
-	memset(skb_data_pool, '\0', max_skb_buf_num*sizeof(struct skb_data));
+
+	memset(skb_data_pool, '\0', max_skb_buf_num * sizeof(struct skb_data));
 	INIT_LIST_HEAD(&skbdata_list);
-	
-	for (i=0; i<max_skb_buf_num; i++) {
+
+	for (i = 0; i < max_skb_buf_num; i++) {
 		INIT_LIST_HEAD(&skb_data_pool[i].list);
 		list_add_tail(&skb_data_pool[i].list, &skbdata_list);
 	}
-	skbdata_used_num = 0;	
+	skbdata_used_num = 0;
 	max_skbdata_used_num = 0;
 }
 
 void deinit_skb_data_pool(void)
 {
 	//printf("\ndeinit_skb_data_pool\n");
-	rtw_mfree((uint8_t*)skb_data_pool, MAX_SKB_BUF_NUM * sizeof(struct skb_data));
+	rtw_mfree((uint8_t *)skb_data_pool, MAX_SKB_BUF_NUM * sizeof(struct skb_data));
 }
 #endif

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
@@ -199,7 +199,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -195,7 +195,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -197,7 +197,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -199,7 +199,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -199,7 +199,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -199,7 +199,6 @@ SRC_CPP += $(CHIPDIR)/src/app/server/CommissioningWindowManager.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDManagementServer.cpp
 SRC_CPP += $(CHIPDIR)/src/app/icd/ICDMonitoringTable.cpp
-SRC_CPP += $(CHIPDIR)/src/app/util/attribute-size-util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-storage.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/attribute-table.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/binding-table.cpp


### PR DESCRIPTION
 * Synchronized code with internal git to match lib_wlan.a and do alignment for buffer
 * Fix build error due to SHA:54c97231c6fcb791da35e59944c227db3e2d5c2b, where attribute-size-util.cpp has been removed