### PR TITLE
[sdk] fix build issue with operational state

### DIFF
--- a/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
@@ -217,6 +217,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
+++ b/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
@@ -213,6 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
+++ b/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
@@ -208,6 +208,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/fan/lib_chip_fan_main.mk
+++ b/component/common/application/matter/example/fan/lib_chip_fan_main.mk
@@ -217,6 +217,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -212,6 +212,7 @@ SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/laundry-
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -216,6 +216,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
@@ -215,6 +215,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
+++ b/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
@@ -210,6 +210,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -216,6 +216,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
@@ -213,6 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -209,6 +209,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -211,6 +211,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -213,6 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -224,7 +225,8 @@ SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/laundry-
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/dishwasher-alarm-stub.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/dishwasher-mode.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/fan-stub.cpp
-# SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
+SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
+SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/rvc-operational-state-delegate-impl.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/resource-monitoring-delegates.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/rvc-modes.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/smco-stub.cpp
@@ -234,7 +236,6 @@ SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/static-s
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/chipinterface.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/BindingHandler.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/ManualOperationCommand.cpp
-SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/OperationalStateManager.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/SmokeCOAlarmManager.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/ameba/main/CHIPDeviceManager.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -213,6 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -213,6 +213,7 @@ SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 
 SRC_CPP += $(CODEGENDIR)/app/callback-stub.cpp
+SRC_CPP += $(CODEGENDIR)/app/cluster-init-callback.cpp
 SRC_CPP += $(CODEGENDIR)/zap-generated/IMClusterCommandHandler.cpp
 
 SRC_CPP += $(CHIPDIR)/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp

--- a/tools/matter/codegen_helpers/expected.outputs
+++ b/tools/matter/codegen_helpers/expected.outputs
@@ -1,2 +1,3 @@
 app/PluginApplicationCallbacks.h
 app/callback-stub.cpp
+app/cluster-init-callback.cpp


### PR DESCRIPTION
* all-clusters-app/ameba operation state has been moved to all-clusters-app/all-clusters-common/src, therefore adding files to fix missing definition.
* add app/cluster-init-callback.cpp for cluster initialization