### PR TITLE
[build] fix build issue with MatterReportingAttributeChangeCallback

### DIFF
--- a/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
@@ -212,6 +212,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
+++ b/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
@@ -205,7 +205,9 @@ SRC_CPP += $(CHIPDIR)/src/app/util/ember-compatibility-functions.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/generic-callback-stubs.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
+
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(CHIPDIR)/src/lib/dnssd/minimal_mdns/responders/IP.cpp
 

--- a/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
+++ b/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
@@ -204,7 +204,10 @@ SRC_CPP += $(CHIPDIR)/src/app/util/ember-compatibility-functions.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/generic-callback-stubs.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
+
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
+
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)

--- a/component/common/application/matter/example/fan/lib_chip_fan_main.mk
+++ b/component/common/application/matter/example/fan/lib_chip_fan_main.mk
@@ -212,6 +212,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -204,7 +204,10 @@ SRC_CPP += $(CHIPDIR)/src/app/util/ember-compatibility-functions.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/generic-callback-stubs.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
+
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
+
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/laundry-washer-mode.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/laundry-washer-controls-delegate-impl.cpp
 SRC_CPP += $(CHIPDIR)/examples/all-clusters-app/all-clusters-common/src/operational-state-delegate-impl.cpp

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -211,6 +211,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
@@ -210,6 +210,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
+++ b/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
@@ -204,7 +204,9 @@ SRC_CPP += $(CHIPDIR)/src/app/util/ember-compatibility-functions.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/generic-callback-stubs.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
+
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -211,6 +211,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
@@ -208,6 +208,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -204,6 +204,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/generic-callback-stubs.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -207,6 +207,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -209,6 +209,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -208,6 +208,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -210,6 +210,7 @@ SRC_CPP += $(CHIPDIR)/src/app/util/util.cpp
 SRC_CPP += $(CHIPDIR)/src/app/util/privilege-storage.cpp
 
 SRC_CPP += $(CHIPDIR)/src/app/reporting/Engine.cpp
+SRC_CPP += $(CHIPDIR)/src/app/reporting/reporting.cpp
 
 SRC_CPP += $(shell cat $(CODEGENDIR)/cluster-file.txt)
 


### PR DESCRIPTION
* MatterReportingAttributeChangeCallback was removed from ember-compatibility-functions.cpp and added into reporting.cpp in SHA:d338455 of connectedhomeip