### PR TITLE
Update system time

### DIFF
--- a/component/common/application/matter/common/port/matter_timers.c
+++ b/component/common/application/matter/common/port/matter_timers.c
@@ -23,7 +23,7 @@
 #define NANOSECONDS_PER_TICK       ( NANOSECONDS_PER_SECOND / configTICK_RATE_HZ ) /**< Nanoseconds per FreeRTOS tick. */
 
 #define US_OVERFLOW_MAX            (0xFFFFFFFF)
-#define MATTER_SW_RTC_TIMER_ID     TIMER4
+#define MATTER_SW_RTC_TIMER_ID     TIMER5
 
 extern int FreeRTOS_errno;
 #define errno FreeRTOS_errno

--- a/component/common/application/matter/common/port/matter_timers.h
+++ b/component/common/application/matter/common/port/matter_timers.h
@@ -19,6 +19,8 @@ time_t _time( time_t * tloc );
 void matter_rtc_init(void);
 long long matter_rtc_read(void);
 void matter_rtc_write(long long time);
+uint64_t ameba_get_clock_time(void);
+void matter_timer_init(void);
 
 #ifdef __cplusplus
 }

--- a/component/common/application/matter/core/matter_core.cpp
+++ b/component/common/application/matter/core/matter_core.cpp
@@ -201,6 +201,7 @@ exit:
 
 CHIP_ERROR matter_core_start()
 {
+    matter_timer_init();
     return matter_core_init();
     // matter_core_init_server();
 }

--- a/component/common/application/matter/core/matter_events.h
+++ b/component/common/application/matter/core/matter_events.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <platform/CHIPDeviceLayer.h>
+#include <app/ConcreteAttributePath.h>
 
 struct AppEvent;
 typedef void (*EventHandler)(AppEvent *);

--- a/component/common/application/matter/driver/dishwasher_mode.h
+++ b/component/common/application/matter/driver/dishwasher_mode.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <app/clusters/mode-base-server/mode-base-server.h>
-#include <app/util/af.h>
+#include <app/util/attribute-table.h>
 #include <app/util/config.h>
 #include <cstring>
 #include <utility>

--- a/component/common/application/matter/driver/fan_driver.h
+++ b/component/common/application/matter/driver/fan_driver.h
@@ -2,7 +2,7 @@
 
 #include <platform_stdlib.h>
 #include "pwmout_api.h"
-#include <app/util/af.h>
+#include <app/util/attribute-table.h>
 
 class MatterFan
 {

--- a/component/common/application/matter/driver/tcc_mode.h
+++ b/component/common/application/matter/driver/tcc_mode.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <app/clusters/mode-base-server/mode-base-server.h>
-#include <app/util/af.h>
+#include <app/util/attribute-table.h>
 #include <app/util/config.h>
 #include <cstring>
 #include <utility>

--- a/component/common/application/matter/example/chiptest/example_matter.c
+++ b/component/common/application/matter/example/chiptest/example_matter.c
@@ -17,7 +17,7 @@ static void example_matter_task_thread(void *pvParameters)
     while(!(wifi_is_up(RTW_STA_INTERFACE) || wifi_is_up(RTW_AP_INTERFACE))) {
         //waiting for Wifi to be initialized
     }
-
+    matter_timer_init();
     ChipTest();
 
     vTaskDelete(NULL);


### PR DESCRIPTION
* Add system time wrapper
* Use gtimer instead of freertos time as freertos only covers until 32-bits, but matter requires 64-bits
* Fix build issue with af.h as header has been removed and declaration is moved to attribute-table.h
