### PR TITLE
[sdk] fix pwm unable to start

### DIFF
--- a/component/common/application/matter/driver/dishwasher_driver.cpp
+++ b/component/common/application/matter/driver/dishwasher_driver.cpp
@@ -4,7 +4,10 @@
 void MatterDishwasher::Init(PinName pin)
 {
     mPwm_obj                        = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
+
     pwmout_init(mPwm_obj, pin);
+    pwmout_period_us(mPwm_obj, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_obj);
 }
 
 void MatterDishwasher::deInit(void)

--- a/component/common/application/matter/driver/fan_driver.cpp
+++ b/component/common/application/matter/driver/fan_driver.cpp
@@ -6,6 +6,8 @@ void MatterFan::Init(PinName pin)
 {
     mPwm_obj                        = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     pwmout_init(mPwm_obj, pin);
+    pwmout_period_us(mPwm_obj, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_obj);
 }
 
 void MatterFan::deInit(void)

--- a/component/common/application/matter/driver/led_driver.cpp
+++ b/component/common/application/matter/driver/led_driver.cpp
@@ -8,6 +8,8 @@ void MatterLED::Init(PinName pin)
     mPwm_obj                        = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
 
     pwmout_init(mPwm_obj, pin);
+    pwmout_period_us(mPwm_obj, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_obj);
 
     mRgb                            = false;
     mState                          = false;
@@ -22,9 +24,18 @@ void MatterLED::Init(PinName redpin, PinName greenpin, PinName bluepin)
     mPwm_red                        = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     mPwm_green                      = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     mPwm_blue                       = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
+
     pwmout_init(mPwm_red, redpin);
+    pwmout_period_us(mPwm_red, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_red);
+
     pwmout_init(mPwm_green, bluepin);
+    pwmout_period_us(mPwm_green, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_green);
+
     pwmout_init(mPwm_blue, greenpin);
+    pwmout_period_us(mPwm_blue, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_blue);
 
     mRgb                            = true;
     mRgbw                           = false;
@@ -42,11 +53,26 @@ void MatterLED::Init(PinName redpin, PinName greenpin, PinName bluepin, PinName 
     mPwm_blue                       = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     mPwm_cwhite                     = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     mPwm_wwhite                     = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
+
     pwmout_init(mPwm_red, redpin);
+    pwmout_period_us(mPwm_red, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_red);
+
     pwmout_init(mPwm_green, bluepin);
+    pwmout_period_us(mPwm_green, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_green);
+
     pwmout_init(mPwm_blue, greenpin);
+    pwmout_period_us(mPwm_blue, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_blue);
+
     pwmout_init(mPwm_cwhite, cwhitepin);
+    pwmout_period_us(mPwm_cwhite, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_cwhite);
+
     pwmout_init(mPwm_wwhite, wwhitepin);
+    pwmout_period_us(mPwm_wwhite, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_wwhite);
 
     mRgb                            = true;
     mRgbw                           = true;

--- a/component/common/application/matter/driver/washer_driver.cpp
+++ b/component/common/application/matter/driver/washer_driver.cpp
@@ -5,6 +5,8 @@ void MatterWasher::Init(PinName pin)
 {
     mPwm_obj                        = (pwmout_t*) pvPortMalloc(sizeof(pwmout_t));
     pwmout_init(mPwm_obj, pin);
+    pwmout_period_us(mPwm_obj, 20000); //pwm period = 20ms
+    pwmout_start(mPwm_obj);
 }
 
 void MatterWasher::deInit(void)

--- a/component/common/mbed/hal/pwmout_api.h
+++ b/component/common/mbed/hal/pwmout_api.h
@@ -124,6 +124,19 @@ void pwmout_pulsewidth_ms(pwmout_t* obj, int ms);
   */
 void pwmout_pulsewidth_us(pwmout_t* obj, int us);
 
+/**
+  * @brief  Start the pulse width of the specified channel in microseconds.
+  * @param  obj: PWM object define in application software.
+  * @retval none
+  */
+void pwmout_start(pwmout_t *obj);
+
+/**
+  * @brief  Stop the pulse width of the specified channel.
+  * @param  obj: PWM object define in application software.
+  * @retval none
+  */
+void pwmout_stop(pwmout_t *obj);
 ///@}
 
 /*\@}*/


### PR DESCRIPTION
* As pwmout_period_us and hal_pwm_enable has been removed in pwmout_init, it requires calling pwmout_period_us and pwmout_start in application to successfully start pwm