### PR TITLE
[sdk] fix diagnostic logs cluster

### DIFF
--- a/component/common/application/matter/common/atcmd/atcmd_matter.c
+++ b/component/common/application/matter/common/atcmd/atcmd_matter.c
@@ -73,11 +73,85 @@ void fATmattershell(void *arg)
     } 
 }
 
+#define CONFIG_ENABLE_AMEBA_DLOG_TEST 1
 #if defined(CONFIG_ENABLE_AMEBA_DLOG_TEST) && (CONFIG_ENABLE_AMEBA_DLOG_TEST == 1)
+extern int requires_bdx;
 void fATcrash(void *arg)
 {
     printf("!@#$ FORCE CRASHING CORE !@#$\n");
+    requires_bdx = 1;
+
     ((void (*)(void))2)();
+
+    return;
+}
+
+void fATcrashbdx(void *arg)
+{
+    printf("!@#$ FORCE CRASHING CORE !@#$\n");
+    requires_bdx = 0;
+
+    ((void (*)(void))2)();
+
+    return;
+}
+
+void fATuserlog(void *arg)
+{
+    if (!arg) {
+        printf("[@@@@]Usage: ####=[size]\n\r");
+        printf("      Set more than 1024 to trigger bdx transfer\n\r");
+        return;
+    }
+
+    size_t dataSize = (size_t)atoi((const char *)arg);
+
+    u8 *data = (u8 *)malloc(dataSize * sizeof(u8));
+    if (data == NULL)
+    {
+        return;
+    }
+
+    const char *logMessage = "Hello World";
+    strncpy((char *)data, logMessage, 11);
+    data[sizeof(data) - 1] = '\0';
+    matter_insert_user_log(data, dataSize);
+
+    if (data)
+    {
+        free(data);
+    }
+
+    return;
+}
+
+void fATnetworklog(void *arg)
+{
+    if (!arg) {
+        printf("[@@@@]Usage: ####=[size]\n\r");
+        printf("      Set more than 1024 to trigger bdx transfer\n\r");
+        return;
+    }
+
+    size_t dataSize = (size_t)atoi((const char *)arg);
+
+    u8 *data = (u8 *)malloc(dataSize * sizeof(u8));
+    if (data == NULL)
+    {
+        return;
+    }
+
+    const char *logMessage = "No Error Found";
+    strncpy((char *)data, logMessage, 14);
+    data[sizeof(data) - 1] = '\0';
+    matter_insert_network_log(data, dataSize);
+
+    if (data)
+    {
+        free(data);
+    }
+
+    return;
 }
 #endif /* CONFIG_ENABLE_AMEBA_DLOG_TEST */
 
@@ -90,6 +164,9 @@ log_item_t at_matter_items[] = {
     {"ATMS", fATmattershell},
 #if defined(CONFIG_ENABLE_AMEBA_DLOG_TEST) && (CONFIG_ENABLE_AMEBA_DLOG_TEST == 1)
     {"@@@@", fATcrash},
+    {"####", fATcrashbdx},
+    {"$$$$", fATuserlog},
+    {"^^^^", fATnetworklog},
 #endif /* CONFIG_ENABLE_AMEBA_DLOG_TEST */
 #endif // end of #if ATCMD_VER == ATVER_1
 #endif

--- a/component/common/application/matter/common/port/matter_fs.c
+++ b/component/common/application/matter/common/port/matter_fs.c
@@ -253,6 +253,11 @@ int matter_fs_fclear(void* fp)
     return lfs_file_truncate(&lfs, lfs_fp, 0);
 }
 
+int matter_fs_remove(const char *path)
+{
+    return lfs_remove(&lfs, path);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/common/port/matter_fs.h
+++ b/component/common/application/matter/common/port/matter_fs.h
@@ -100,6 +100,14 @@ int matter_fs_fsize(void* fp);
  */
 int matter_fs_fclear(void* fp);
 
+/**
+ * @brief Removes a file from the filesystem.
+ *
+ * @param path The path of the file to be removed.
+ * @return int 0 for success; otherwise, a non-zero error code indicating the type of failure.
+ */
+int matter_fs_remove(const char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
+++ b/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
@@ -163,6 +163,22 @@ CHIP_ERROR AmebaDiagnosticLogsProvider::EndLogCollection(LogSessionHandle sessio
     // WARNING: If the handle is closed, it needs to be reopened or will assert in LFS layer on future calls
     matter_fs_fclear(fp);  // Since the file has been read, it is safe to clear it
 
+    if (fp == &fpUserLog)
+    {
+        ChipLogProgress(DeviceLayer, "Removing Logs for User logs");
+        matter_fs_remove(USER_LOG_FILENAME);
+    }
+    else if (fp == &fpNetdiagLog)
+    {
+        ChipLogProgress(DeviceLayer, "Removing Logs for Network logs");
+        matter_fs_remove(NET_LOG_FILENAME);
+    }
+    else if (fp == &fpCrashLog)
+    {
+        ChipLogProgress(DeviceLayer, "Removing Logs for Crash logs");
+        matter_fs_remove(CRASH_LOG_FILENAME);
+    }
+
     mLogFiles.erase(sessionHandle);  // Remove the session handle from the map
 
     ChipLogProgress(DeviceLayer, "Log Collection Ended");

--- a/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
+++ b/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
@@ -1,0 +1,64 @@
+#include <FreeRTOS.h>
+#include <platform_stdlib.h>
+#include <platform_opts.h>
+#include <device_lock.h>
+#include <flash_api.h>
+#include <string>
+
+#if defined(CONFIG_ENABLE_AMEBA_DLOG) && (CONFIG_ENABLE_AMEBA_DLOG == 1)
+#include <lfs.h>
+#include <matter_fs.h>
+
+#include <diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+_WEAK void matter_insert_user_log(uint8_t* data, uint32_t data_len)
+{
+    lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpUserLog();
+    int res;
+    uint unused_writecount = 0;
+
+    ChipLogProgress(DeviceLayer, "Copy User log.....");
+
+    res = matter_fs_fwrite(fp, data, data_len, &unused_writecount); // write to FS
+    if (res >= 0)
+    {
+        ChipLogProgress(DeviceLayer, "Wrote %d bytes to userlog", unused_writecount);
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Write error! %d", res);
+        return;
+    }
+
+    return;
+}
+
+_WEAK void matter_insert_network_log(uint8_t* data, uint32_t data_len)
+{
+    lfs_file_t* fp = chip::app::Clusters::DiagnosticLogs::AmebaDiagnosticLogsProvider::GetFpNetdiagLog();
+    int res;
+    uint unused_writecount = 0;
+
+    ChipLogProgress(DeviceLayer, "Copy Network log.....");
+
+    res = matter_fs_fwrite(fp, data, data_len, &unused_writecount); // write to FS
+    if (res >= 0)
+    {
+        ChipLogProgress(DeviceLayer, "Wrote %d bytes to Networklog", unused_writecount);
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Write error! %d", res);
+        return;
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONFIG_ENABLE_AMEBA_DLOG */

--- a/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.h
+++ b/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.h
@@ -1,0 +1,28 @@
+#ifndef MATTER_AMEBA_FAULTLOG_H
+#define MATTER_AMEBA_FAULTLOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Inserts user log data into the logging system.
+ * 
+ * @param data Pointer to the data to be logged.
+ * @param data_len Length of the data in bytes.
+ */
+_WEAK void matter_insert_user_log(uint8_t* data, uint32_t data_len);
+
+/**
+ * @brief Inserts network log data into the logging system.
+ * 
+ * @param data Pointer to the network log data to be logged.
+ * @param data_len Length of the data in bytes.
+ */
+_WEAK void matter_insert_network_log(uint8_t* data, uint32_t data_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MATTER_AMEBA_FAULTLOG_H

--- a/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
+++ b/component/common/application/matter/example/aircon/lib_chip_aircon_main.mk
@@ -238,6 +238,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
+++ b/component/common/application/matter/example/bridge_dm/lib_chip_bridge_main.mk
@@ -240,6 +240,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
+++ b/component/common/application/matter/example/dishwasher/lib_chip_dishwasher_main.mk
@@ -240,6 +240,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/fan/lib_chip_fan_main.mk
+++ b/component/common/application/matter/example/fan/lib_chip_fan_main.mk
@@ -237,6 +237,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
+++ b/component/common/application/matter/example/laundrywasher/lib_chip_laundrywasher_main.mk
@@ -239,6 +239,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/light/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light/lib_chip_light_main.mk
@@ -241,6 +241,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
+++ b/component/common/application/matter/example/light_dm/lib_chip_light_main.mk
@@ -242,6 +242,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
+++ b/component/common/application/matter/example/refrigerator/lib_chip_refrigerator_main.mk
@@ -236,6 +236,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
+++ b/component/common/application/matter/example/thermostat/lib_chip_thermostat_main.mk
@@ -242,6 +242,7 @@ SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(SDKROOTDIR)/component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_air_purifier_main.mk
@@ -241,6 +241,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_chef_main.mk
@@ -234,6 +234,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_light_main.mk
@@ -238,6 +238,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_main.mk
@@ -267,6 +267,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_otar_main.mk
@@ -239,6 +239,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 

--- a/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
+++ b/project/realtek_amebaz2_v0_example/GCC-RELEASE/lib_chip_switch_main.mk
@@ -243,6 +243,7 @@ SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_ap
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/api/matter_log_api.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_diagnosticlogs_provider_delegate_impl.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_faultlog.cpp
+SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_insert_logs.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_handler.cpp
 SRC_CPP += $(BASEDIR)/../../../component/common/application/matter/driver/diagnostic_logs/ameba_logging_redirect_wrapper.cpp
 


### PR DESCRIPTION
* fix failure when testing TC-DLOG-2.1

Notes:
* Failed to erase data from file system, so must remove when EndLogCollection is called
* Failed to trigger Success (status=0), have to insert data first
* Failed to trigger Exhaust (status=1), have to insert data which is less than 1024
* Added ATcmd for inserting logs: 
 -. $$$$=1025 (or above) to get user log with status = 0 
 -. $$$$=1024 (or below) to get user log with status = 1 
 -. ^^^^=1025 (or above) to get network log with status = 0 
 -. ^^^^=1024 (or below) to get network log with status = 1 
 -. #### to get crash log with status = 0 
 -. @@@@ to get crash log with status = 1 
 -. Don't insert any logs to get status = 2